### PR TITLE
:computer: Add Print Formatting for Chapter One Code Two

### DIFF
--- a/chapter1/code2/Makefile
+++ b/chapter1/code2/Makefile
@@ -1,0 +1,80 @@
+.phony := clean
+ifeq (,$(filter $(phony), $(MAKECMDGOALS)))
+
+ifndef ARCH
+$(error ARCH is not specified)
+endif
+
+ifndef BOARD
+$(error BOARD is not specified)
+endif
+
+endif
+
+ARMCCC = aarch64-linux-gnu
+CFLAGS = -Wall -nostdlib -nostartfiles -ffreestanding -mgeneral-regs-only
+
+BUILD_DIR = .build/
+LIB_DIR = $(BUILD_DIR)/libs
+
+BOARD_SRC_DIR = arch/$(ARCH)/board/$(BOARD)/
+BOARD_OBJ_DIR = $(BUILD_DIR)/board/
+BOARD_C_FILES = $(wildcard $(BOARD_SRC_DIR)/*.c)
+BOARD_S_FILES = $(wildcard $(BOARD_SRC_DIR)/*.S)
+BOARD_OBJ_FILES = $(BOARD_C_FILES:$(BOARD_SRC_DIR)/%.c=$(BOARD_OBJ_DIR)/%_c.o) $(BOARD_S_FILES:$(BOARD_SRC_DIR)/%.S=$(BOARD_OBJ_DIR)/%_s.o)
+BOARD_INCLUDE_DIR = $(BOARD_SRC_DIR)/include/
+
+ARCH_SRC_DIR = arch/$(ARCH)/
+ARCH_OBJ_DIR = $(BUILD_DIR)/arch/
+ARCH_C_FILES = $(wildcard $(ARCH_SRC_DIR)/*.c)
+ARCH_S_FILES = $(wildcard $(ARCH_SRC_DIR)/*.S)
+ARCH_OBJ_FILES = $(ARCH_C_FILES:$(ARCH_SRC_DIR)/%.c=$(ARCH_OBJ_DIR)/%_c.o) $(ARCH_S_FILES:$(ARCH_SRC_DIR)/%.S=$(ARCH_OBJ_DIR)/%_s.o)
+ARCH_INCLUDE_DIR = $(ARCH_SRC_DIR)/include/
+
+KERNEL_SRC_DIR = src/
+KERNEL_OBJ_DIR = $(BUILD_DIR)/kernel/
+KERNEL_C_FILES = $(wildcard $(KERNEL_SRC_DIR)/*.c)
+KERNEL_OBJ_FILES = $(KERNEL_C_FILES:$(KERNEL_SRC_DIR)/%.c=$(KERNEL_OBJ_DIR)/%.o)
+KERNEL_INCLUDE_DIR = include/
+
+all: kernel8.img
+
+kernel8.img: $(ARCH_SRC_DIR)/linker.ld $(ARCH_OBJ_FILES) $(LIB_DIR)/libboard.a $(LIB_DIR)/libcheesecake.a
+	$(ARMCCC)-ld -T $(ARCH_SRC_DIR)/linker.ld -o $(BUILD_DIR)/kernel8.elf  $(ARCH_OBJ_FILES) -L$(LIB_DIR) -lboard -lcheesecake -lboard
+	$(ARMCCC)-objdump -d $(BUILD_DIR)/kernel8.elf > $(BUILD_DIR)/kernel8.dsa
+	$(ARMCCC)-nm -n $(BUILD_DIR)/kernel8.elf > $(BUILD_DIR)/kernel8.map
+	$(ARMCCC)-objcopy $(BUILD_DIR)/kernel8.elf -O binary kernel8.img
+
+$(ARCH_OBJ_DIR)/%_c.o: $(ARCH_SRC_DIR)/%.c
+	mkdir -p $(@D)
+	$(ARMCCC)-gcc $(CFLAGS) -I$(KERNEL_INCLUDE_DIR) -I$(ARCH_INCLUDE_DIR) -MMD -c $< -o $@
+
+$(ARCH_OBJ_DIR)/%_s.o: $(ARCH_SRC_DIR)/%.S
+	mkdir -p $(@D)
+	$(ARMCCC)-gcc $(CFLAGS) -I$(KERNEL_INCLUDE_DIR) -I$(ARCH_INCLUDE_DIR) -MMD -c $< -o $@
+
+$(LIB_DIR)/libboard.a: $(BOARD_OBJ_FILES)
+	mkdir -p $(@D)
+	$(ARMCCC)-ar crs $(LIB_DIR)/libboard.a $(BOARD_OBJ_FILES)
+
+$(BOARD_OBJ_DIR)/%_s.o: $(BOARD_SRC_DIR)/%.S
+	mkdir -p $(@D)
+	$(ARMCCC)-gcc -I$(BOARD_INCLUDE_DIR) -I$(ARCH_INCLUDE_DIR) -I$(KERNEL_INCLUDE_DIR) -MMD -c $< -o $@
+
+$(BOARD_OBJ_DIR)/%_c.o: $(BOARD_SRC_DIR)/%.c
+	mkdir -p $(@D)
+	$(ARMCCC)-gcc $(CFLAGS) -I$(BOARD_INCLUDE_DIR) -I$(ARCH_INCLUDE_DIR) -I$(KERNEL_INCLUDE_DIR) -MMD -c $< -o $@
+
+$(LIB_DIR)/libcheesecake.a: $(KERNEL_OBJ_FILES)
+	mkdir -p $(@D)
+	$(ARMCCC)-ar crs $(LIB_DIR)/libcheesecake.a $(KERNEL_OBJ_FILES)
+
+$(KERNEL_OBJ_DIR)/%.o: $(KERNEL_SRC_DIR)/%.c
+	mkdir -p $(@D)
+	$(ARMCCC)-gcc $(CFLAGS) -I$(KERNEL_INCLUDE_DIR) -I$(ARCH_INCLUDE_DIR) -MMD -c $< -o $@
+
+DEP_FILES = $(OBJ_FILES:%.o=%.d)
+-include $(DEP_FILES)
+
+clean:
+	rm -rf $(BUILD_DIR) *.img

--- a/chapter1/code2/arch/arm64/board/raspberry-pi-4/config.txt
+++ b/chapter1/code2/arch/arm64/board/raspberry-pi-4/config.txt
@@ -1,0 +1,6 @@
+arm_64bit=1
+arm_peri_high=1
+disable_commandline_tags=1
+enable_gic=1
+enable_uart=1
+kernel_old=1

--- a/chapter1/code2/arch/arm64/board/raspberry-pi-4/mini-uart.S
+++ b/chapter1/code2/arch/arm64/board/raspberry-pi-4/mini-uart.S
@@ -1,0 +1,56 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define MAIN_PERIPH_BASE        (0x47C000000)
+#define UART_BASE_REG           (MAIN_PERIPH_BASE + 0x2215000)
+#define AUX_MU_IO_REG           ((UART_BASE_REG) + 0x40)
+#define AUX_MU_LSR_REG          ((UART_BASE_REG) + 0x54)
+#define AUX_MU_LSR_REG_TISHIFT  (6)
+#define AUX_MU_LSR_REG_TIFLAG   (1 << (AUX_MU_LSR_REG_TISHIFT))
+
+    .macro __MOV_Q, reg, val
+	    .if     (((\val) >> 31) == 0 || ((\val) >> 31) == 0x1ffffffff)
+	    movz	\reg, :abs_g1_s:\val
+	    .else
+	    .if     (((\val) >> 47) == 0 || ((\val) >> 47) == 0x1ffff)
+	    movz	\reg, :abs_g2_s:\val
+	    .else
+	    movz	\reg, :abs_g3:\val
+	    movk	\reg, :abs_g2_nc:\val
+	    .endif
+	    movk	\reg, :abs_g1_nc:\val
+	    .endif
+	    movk	\reg, :abs_g0_nc:\val
+	.endm
+
+    .macro __DEV_READ_32, dst, src
+        ldr     \dst, [\src]
+    .endm
+
+    .macro __DEV_WRITE_8, src, dst
+        strb   \src, [\dst]
+    .endm
+
+.globl __uart_can_io
+__uart_can_io:
+    __MOV_Q         x0, AUX_MU_LSR_REG
+    __DEV_READ_32   w0, x0
+    and             w0, w0, AUX_MU_LSR_REG_TIFLAG
+    ret
+
+.globl __uart_putchar
+__uart_putchar:
+    __MOV_Q         x1, AUX_MU_IO_REG
+    __DEV_WRITE_8   w0, x1
+    ret

--- a/chapter1/code2/arch/arm64/board/raspberry-pi-4/mini-uart.c
+++ b/chapter1/code2/arch/arm64/board/raspberry-pi-4/mini-uart.c
@@ -1,0 +1,49 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cake/log.h"
+
+extern int  __uart_can_io();
+extern void __uart_putchar(char c);
+
+static void uart_puts(char *s);
+static struct console console = {
+    .write = uart_puts
+};
+
+static inline int check_ready()
+{
+    return __uart_can_io();
+}
+
+static inline void uart_putchar(char c)
+{
+    while(!check_ready()) {
+    }
+    return __uart_putchar(c);
+}
+
+void console_init()
+{
+    register_console(&console);
+}
+
+static void uart_puts(char *s)
+{
+    if(s) {
+        for(char *str = s; *str != '\0'; str++) {
+            uart_putchar(*str);
+        }
+    }
+}

--- a/chapter1/code2/arch/arm64/include/arch/timing.h
+++ b/chapter1/code2/arch/arm64/include/arch/timing.h
@@ -1,0 +1,22 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _ARCH_TIMING_H
+#define _ARCH_TIMING_H
+
+#define DELAY __delay
+
+void __delay(unsigned long delay);
+
+#endif

--- a/chapter1/code2/arch/arm64/linker.ld
+++ b/chapter1/code2/arch/arm64/linker.ld
@@ -1,0 +1,19 @@
+OUTPUT_ARCH(aarch64)
+ENTRY(_start)
+SECTIONS
+{
+    . = 0x0;
+    .text.boot : {
+        _start = .;
+        *(.text.boot)
+    }
+    .text : { *(.text) }
+    .rodata : { *(.rodata) }
+    .data : { *(.data) }
+    . = ALIGN(0x8);
+    bss_begin = .;
+    .bss : { *(.bss*) }
+    bss_end = .;
+    . = 0x400000;
+    _end = .;
+}

--- a/chapter1/code2/arch/arm64/main.S
+++ b/chapter1/code2/arch/arm64/main.S
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 1994-2002 Russell King
+ * Copyright (C) 2003-2012 ARM Ltd.
+ * Authors: Catalin Marinas <catalin.marinas@arm.com>
+ *      Will Deacon <will.deacon@arm.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.section ".text.boot"
+
+.globl __entry
+__entry:
+    mrs     x0, mpidr_el1
+    and     x0, x0, #0xFF
+    cbz     x0, __run
+    b       __sleep
+
+__sleep:
+    wfe
+    b       __sleep
+
+__run:
+    adr     x0, bss_begin
+    adr     x1, bss_end
+    bl      __zerobss
+    adrp    x13, _end
+    mov     sp, x13
+    bl      cheesecake_main
+    b       __sleep
+
+__zerobss:
+    sub     x1, x1, x0
+    str     xzr, [x0], #8
+    subs    x1, x1, #8
+    b.gt    __zerobss
+    ret

--- a/chapter1/code2/arch/arm64/timing.S
+++ b/chapter1/code2/arch/arm64/timing.S
@@ -1,0 +1,19 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.globl __delay
+__delay:
+    subs    x0, x0, #1
+    bne     __delay
+    ret

--- a/chapter1/code2/build.sh
+++ b/chapter1/code2/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run --rm -v $(pwd):/ccos4rbpi -w /ccos4rbpi -u $(id -u ) ccos4rbpi make $@ ARCH=arm64 BOARD=raspberry-pi-4

--- a/chapter1/code2/include/cake/log.h
+++ b/chapter1/code2/include/cake/log.h
@@ -1,0 +1,25 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _CAKE_LOG_H
+#define _CAKE_LOG_H
+
+struct console {
+    void (*write)(char *s);
+};
+
+void log(char *fmt, ...);
+void register_console(struct console *c);
+
+#endif

--- a/chapter1/code2/include/cake/string.h
+++ b/chapter1/code2/include/cake/string.h
@@ -1,0 +1,20 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _CAKE_STRING_H
+#define _CAKE_STRING_H
+
+void xintos(unsigned x, char *t);
+
+#endif

--- a/chapter1/code2/include/cake/types.h
+++ b/chapter1/code2/include/cake/types.h
@@ -1,0 +1,39 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _CAKE_TYPES_H
+#define _CAKE_TYPES_H
+
+typedef __signed__ char __s8;
+typedef unsigned char __u8;
+
+typedef __signed__ short __s16;
+typedef unsigned short __u16;
+
+typedef __signed__ int __s32;
+typedef unsigned int __u32;
+
+__extension__ typedef __signed__ long long __s64;
+__extension__ typedef unsigned long long __u64;
+
+typedef __s8  s8;
+typedef __u8  u8;
+typedef __s16 s16;
+typedef __u16 u16;
+typedef __s32 s32;
+typedef __u32 u32;
+typedef __s64 s64;
+typedef __u64 u64;
+
+#endif

--- a/chapter1/code2/src/cheesecake.c
+++ b/chapter1/code2/src/cheesecake.c
@@ -1,0 +1,39 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cake/log.h"
+#include "arch/timing.h"
+
+extern void log_init();
+void init();
+
+void cheesecake_main(void)
+{
+    unsigned long count = 1;
+    char *version = "0.1.3";
+    init();
+    log("Hello, Cheesecake!\r\n");
+    while (1) {
+        log("Version: %s\r\n", version);
+        log("Message count: %x\r\n", count++);
+        log("\r\n");
+        DELAY(20000000);
+    }
+}
+
+void init()
+{
+    log_init();
+    log("LOG MODULE INITIALIZED\r\n");
+}

--- a/chapter1/code2/src/log.c
+++ b/chapter1/code2/src/log.c
@@ -1,0 +1,137 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdarg.h>
+#include "cake/types.h"
+#include "cake/log.h"
+#include "cake/string.h"
+
+#define BUFFER_SIZE                     (255)
+#define MAX_BUFFER_DATA_FOR_NULL_TERM   (BUFFER_SIZE - 1)
+
+struct writebuf {
+    u8 pos;
+    char s[BUFFER_SIZE];
+};
+
+static void flush(struct writebuf *w);
+static int puthex(unsigned long x, struct writebuf *w);
+static int putstr(char *s, struct writebuf *w);
+
+extern void console_init();
+
+static struct console *console;
+
+static int check_flush(struct writebuf *w)
+{
+    if(w->pos == MAX_BUFFER_DATA_FOR_NULL_TERM) {
+        flush(w);
+        return 1;
+    }
+    return 0;
+}
+
+static void cleanbuf(struct writebuf *w)
+{
+    w->pos = 0;
+    for(unsigned int i = 0; i < BUFFER_SIZE; i++) {
+        w->s[i] = 0;
+    }
+}
+
+static void flush(struct writebuf *w)
+{
+    if(w->pos) {
+        console->write(w->s);
+    }
+}
+
+void log(char *fmt, ...)
+{
+    char c;
+    va_list va;
+    va_start(va, fmt);
+    struct writebuf w;
+    cleanbuf(&w);
+    while((c = *(fmt++)) != '\0') {
+        if(c != '%') {
+            w.s[w.pos++] = c;
+            if(check_flush(&w)) {
+                va_end(va);
+                return;
+            }
+        }
+        else {
+            int ret;
+            c = *(fmt++);
+            switch(c)
+            {
+                case 's':
+                    ret = putstr(va_arg(va, char*), &w);
+                    if(ret) {
+                        va_end(va);
+                        return;
+                    }
+                    break;
+                case 'x':
+                    ret = puthex(va_arg(va, unsigned long), &w);
+                    if(ret) {
+                        va_end(va);
+                        return;
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+    flush(&w);
+    va_end(va);
+}
+
+void log_init()
+{
+    console_init();
+}
+
+static int puthex(unsigned long x, struct writebuf *w)
+{
+    char c, d = 0;
+    char temp[30];
+    xintos(x, temp);
+    while((c = temp[d++]) != '\0') {
+        w->s[w->pos++] = c;
+        if(check_flush(w)) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int putstr(char *s, struct writebuf *w)
+{
+    char c;
+    while((c = *s++)  != '\0') {
+        w->s[w->pos++] = c;
+        if(check_flush(w)) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+void register_console(struct console *c)
+{
+    console = c;
+}

--- a/chapter1/code2/src/string.c
+++ b/chapter1/code2/src/string.c
@@ -1,0 +1,36 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+void xintos(unsigned long x, char *t)
+{
+    int temp_size = 0;
+    char c, temp[16];
+    *(t++) = '0';
+    *(t++) = 'x';
+    do {
+        c = x % 16;
+        if(c < 10) {
+            c = c + 0x30;
+        } else {
+            c = c + 0x37;
+        }
+        temp[temp_size++] = c;
+        x /= 16;
+    } while(x);
+    while(temp_size--) {
+        *(t++) = temp[temp_size];
+    }
+    *(t++) = '\0';
+    return;
+}


### PR DESCRIPTION
Problem:
---
- Print formatting is missing from the implementation
- Though annoying print formatting is valuable

Solution:
---
- Update log module with va_args formatting
- Support
  - C strings
  - Hex
- Create string module with xintos function
- Add in chapter1/code2

Issue: #26