### PR TITLE
:bug: Move getting-started.sh to setup-docker-aws.sh

### DIFF
--- a/setup-docker-aws.sh
+++ b/setup-docker-aws.sh
@@ -15,5 +15,6 @@ sudo add-apt-repository \
     stable"
 sudo apt-get update
 sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+sudo groupadd docker
+sudo usermod -aG docker ubuntu
 sudo docker run hello-world
-docker build -t ccos4rbpi -f Dockerfile .


### PR DESCRIPTION
Problem:
---
- The getting-started.sh script will not work due to requirements to add docker group and logout/login shell
- This script should not be required, so rename it to a more optional name

Solution:
---
- Renamed script to be setup-docker-aws.sh
- Add ubuntu to docker group

Issue: #31