### PR TITLE
:art: Remove Warning From Chapter One Code Two puthex Function

### DIFF
--- a/chapter1/code2/src/log.c
+++ b/chapter1/code2/src/log.c
@@ -107,8 +107,9 @@ void log_init()
 
 static int puthex(unsigned long x, struct writebuf *w)
 {
-    char c, d = 0;
-    char temp[30];
+    char c;
+    int d = 0;
+    char temp[27];
     xintos(x, temp);
     while((c = temp[d++]) != '\0') {
         w->s[w->pos++] = c;


### PR DESCRIPTION
Problem:
---
- When using char for indexing, gcc gives warning

Solution:
---
- Update variable to be an int
- Update stack variables in puthex function to take up 32 bytes

Issue: #33