### PR TITLE
:computer: Add Timer Initialization in Chapter Two Code Three

### DIFF
--- a/chapter2/code3/Makefile
+++ b/chapter2/code3/Makefile
@@ -1,0 +1,102 @@
+phony := clean exec
+ifeq (,$(filter $(phony), $(MAKECMDGOALS)))
+
+ifndef ARCH
+$(error ARCH is not specified)
+endif
+
+ifndef BOARD
+$(error BOARD is not specified)
+endif
+
+endif
+
+ARMCCC = aarch64-linux-gnu
+CFLAGS = -Wall -nostdlib -nostartfiles -ffreestanding -mgeneral-regs-only
+
+BUILD_DIR = .build/
+LIB_DIR = $(BUILD_DIR)/libs
+
+BOARD_SRC_DIR = arch/$(ARCH)/board/$(BOARD)/
+BOARD_OBJ_DIR = $(BUILD_DIR)/board/
+BOARD_C_FILES = $(wildcard $(BOARD_SRC_DIR)/*.c)
+BOARD_S_FILES = $(wildcard $(BOARD_SRC_DIR)/*.S)
+BOARD_OBJ_FILES = $(BOARD_C_FILES:$(BOARD_SRC_DIR)/%.c=$(BOARD_OBJ_DIR)/%_c.o) $(BOARD_S_FILES:$(BOARD_SRC_DIR)/%.S=$(BOARD_OBJ_DIR)/%_s.o)
+BOARD_INCLUDE_DIR = $(BOARD_SRC_DIR)/include/
+
+ARCH_SRC_DIR = arch/$(ARCH)/
+ARCH_OBJ_DIR = $(BUILD_DIR)/arch/
+ARCH_C_FILES = $(wildcard $(ARCH_SRC_DIR)/*.c)
+ARCH_S_FILES = $(wildcard $(ARCH_SRC_DIR)/*.S)
+ARCH_OBJ_FILES = $(ARCH_C_FILES:$(ARCH_SRC_DIR)/%.c=$(ARCH_OBJ_DIR)/%_c.o) $(ARCH_S_FILES:$(ARCH_SRC_DIR)/%.S=$(ARCH_OBJ_DIR)/%_s.o)
+ARCH_INCLUDE_DIR = $(ARCH_SRC_DIR)/include/
+
+EXEC_SRC_DIR = $(ARCH_SRC_DIR)/exec/
+EXEC_OBJ_DIR = $(BUILD_DIR)/exec/
+EXEC_GEN_DIR = $(BUILD_DIR)/exec/generated/
+
+KERNEL_SRC_DIR = src/
+KERNEL_OBJ_DIR = $(BUILD_DIR)/kernel/
+KERNEL_C_FILES = $(wildcard $(KERNEL_SRC_DIR)/*.c)
+KERNEL_OBJ_FILES = $(KERNEL_C_FILES:$(KERNEL_SRC_DIR)/%.c=$(KERNEL_OBJ_DIR)/%.o)
+KERNEL_INCLUDE_DIR = include/
+
+.PHONY: $(phony)
+
+all: kernel8.img
+
+kernel8.img: $(ARCH_SRC_DIR)/linker.ld $(ARCH_OBJ_FILES) $(LIB_DIR)/libboard.a $(LIB_DIR)/libcheesecake.a
+	$(ARMCCC)-ld -T $(ARCH_SRC_DIR)/linker.ld -o $(BUILD_DIR)/kernel8.elf  $(ARCH_OBJ_FILES) -L$(LIB_DIR) -lboard -lcheesecake -lboard
+	$(ARMCCC)-objdump -d $(BUILD_DIR)/kernel8.elf > $(BUILD_DIR)/kernel8.dsa
+	$(ARMCCC)-nm -n $(BUILD_DIR)/kernel8.elf > $(BUILD_DIR)/kernel8.map
+	$(ARMCCC)-objcopy $(BUILD_DIR)/kernel8.elf -O binary kernel8.img
+
+$(ARCH_OBJ_DIR)/%_c.o: $(ARCH_SRC_DIR)/%.c
+	mkdir -p $(@D)
+	$(ARMCCC)-gcc $(CFLAGS) -I$(KERNEL_INCLUDE_DIR) -I$(ARCH_INCLUDE_DIR) -I$(EXEC_GEN_DIR) -MMD -c $< -o $@
+
+$(ARCH_OBJ_DIR)/%_s.o: $(ARCH_SRC_DIR)/%.S
+	mkdir -p $(@D)
+	$(ARMCCC)-gcc $(CFLAGS) -I$(KERNEL_INCLUDE_DIR) -I$(ARCH_INCLUDE_DIR) -I$(EXEC_GEN_DIR) -MMD -c $< -o $@
+
+$(LIB_DIR)/libboard.a: $(BOARD_OBJ_FILES)
+	mkdir -p $(@D)
+	$(ARMCCC)-ar crs $(LIB_DIR)/libboard.a $(BOARD_OBJ_FILES)
+
+$(BOARD_OBJ_DIR)/%_s.o: $(BOARD_SRC_DIR)/%.S
+	mkdir -p $(@D)
+	$(ARMCCC)-gcc $(CFLAGS) -I$(BOARD_INCLUDE_DIR) -I$(ARCH_INCLUDE_DIR) -I$(KERNEL_INCLUDE_DIR) -I$(EXEC_GEN_DIR) -MMD -c $< -o $@
+
+$(BOARD_OBJ_DIR)/%_c.o: $(BOARD_SRC_DIR)/%.c
+	mkdir -p $(@D)
+	$(ARMCCC)-gcc $(CFLAGS) -I$(BOARD_INCLUDE_DIR) -I$(ARCH_INCLUDE_DIR) -I$(KERNEL_INCLUDE_DIR) -I$(EXEC_GEN_DIR) -MMD -c $< -o $@
+
+$(LIB_DIR)/libcheesecake.a: $(KERNEL_OBJ_FILES)
+	mkdir -p $(@D)
+	$(ARMCCC)-ar crs $(LIB_DIR)/libcheesecake.a $(KERNEL_OBJ_FILES)
+
+$(KERNEL_OBJ_DIR)/%.o: $(KERNEL_SRC_DIR)/%.c
+	mkdir -p $(@D)
+	$(ARMCCC)-gcc $(CFLAGS) -I$(KERNEL_INCLUDE_DIR) -I$(ARCH_INCLUDE_DIR) -MMD -c $< -o $@
+
+DEP_FILES = $(OBJ_FILES:%.o=%.d)
+-include $(DEP_FILES)
+
+clean:
+	rm -rf $(BUILD_DIR) *.img
+
+exec: $(EXEC_GEN_DIR)/exec/asm-offsets.h
+
+$(EXEC_GEN_DIR)/exec/asm-offsets.h: $(EXEC_GEN_DIR)/asm-offsets
+	mkdir -p $(@D)
+	$< > $@
+	
+$(EXEC_GEN_DIR)/asm-offsets: $(EXEC_OBJ_DIR)/asm-offsets.o
+	mkdir -p $(@D)
+	gcc $< -o $@
+
+$(EXEC_OBJ_DIR)/asm-offsets.o: $(EXEC_SRC_DIR)/asm-offsets.c
+	mkdir -p $(@D)
+	gcc -I$(KERNEL_INCLUDE_DIR) -I$(ARCH_INCLUDE_DIR) -c $< -o $@
+
+

--- a/chapter2/code3/arch/arm64/board/raspberry-pi-4/config.txt
+++ b/chapter2/code3/arch/arm64/board/raspberry-pi-4/config.txt
@@ -1,0 +1,6 @@
+arm_64bit=1
+arm_peri_high=1
+disable_commandline_tags=1
+enable_gic=1
+enable_uart=1
+kernel_old=1

--- a/chapter2/code3/arch/arm64/board/raspberry-pi-4/include/board/bare-metal.h
+++ b/chapter2/code3/arch/arm64/board/raspberry-pi-4/include/board/bare-metal.h
@@ -1,0 +1,24 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _BOARD_BARE_METAL_H
+#define _BOARD_BARE_METAL_H
+
+#define CPU0_MASK       0b0001
+#define CPU1_MASK       0b0010
+#define CPU2_MASK       0b0100
+#define CPU3_MASK       0b1000
+#define CPUALL_MASK     0b1111
+
+#endif

--- a/chapter2/code3/arch/arm64/board/raspberry-pi-4/include/board/devio.h
+++ b/chapter2/code3/arch/arm64/board/raspberry-pi-4/include/board/devio.h
@@ -1,0 +1,33 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _H_BOARD_DEVIO_H
+#define _H_BOARD_DEVIO_H
+
+    .macro __DEV_READ_32, dst, src
+        ldr     \dst, [\src]
+        dsb     ld
+    .endm
+
+    .macro __DEV_WRITE_32, src, dst
+        dsb     st
+        str     \src, [\dst]
+    .endm
+
+    .macro __DEV_WRITE_8, src, dst
+        dsb     st
+        strb    \src, [\dst]
+    .endm
+
+#endif

--- a/chapter2/code3/arch/arm64/board/raspberry-pi-4/include/board/gic.h
+++ b/chapter2/code3/arch/arm64/board/raspberry-pi-4/include/board/gic.h
@@ -1,0 +1,88 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _BOARD_GIC_H
+#define _BOARD_GIC_H
+
+#include "board/peripheral.h"
+
+#define GIC_BASE_REG                (GIC_BASE)
+#define GIC_DISTR_OFFSET            ((GIC_BASE_REG) + 0x1000)
+#define GICD_CTLR                   ((GIC_DISTR_OFFSET) + 0x000)
+#define GICD_TYPER                  ((GIC_DISTR_OFFSET) + 0x004)
+#define GICD_IIDR                   ((GIC_DISTR_OFFSET) + 0x008)
+#define GICD_IGROUPR_OFFSET         ((GIC_DISTR_OFFSET) + 0x080)
+#define GICD_IGROUPR0               ((GIC_DISTR_OFFSET) + 0x080)
+#define GICD_IGROUPR1               ((GIC_DISTR_OFFSET) + 0x084)
+#define GICD_IGROUPR2               ((GIC_DISTR_OFFSET) + 0x088)
+#define GICD_IGROUPR3               ((GIC_DISTR_OFFSET) + 0x08C)
+#define GICD_IGROUPR4               ((GIC_DISTR_OFFSET) + 0x090)
+#define GICD_IGROUPR5               ((GIC_DISTR_OFFSET) + 0x094)
+#define GICD_IGROUPR6               ((GIC_DISTR_OFFSET) + 0x098)
+#define GICD_IGROUPR7               ((GIC_DISTR_OFFSET) + 0x09C)
+#define GICD_ISENABLER_OFFSET       ((GIC_DISTR_OFFSET) + 0x100)
+#define GICD_ISENABLER0             ((GICD_ISENABLER_OFFSET) + 0x00)
+#define GICD_ISENABLER1             ((GICD_ISENABLER_OFFSET) + 0x04)
+#define GICD_ISENABLER2             ((GICD_ISENABLER_OFFSET) + 0x08)
+#define GICD_ISENABLER3             ((GICD_ISENABLER_OFFSET) + 0x0C)
+#define GICD_ISENABLER4             ((GICD_ISENABLER_OFFSET) + 0x10)
+#define GICD_ISENABLER5             ((GICD_ISENABLER_OFFSET) + 0x14)
+#define GICD_ISENABLER6             ((GICD_ISENABLER_OFFSET) + 0x18)
+#define GICD_ISENABLER7             ((GICD_ISENABLER_OFFSET) + 0x1C)
+#define GICD_ISPENDINGR_OFFSET      ((GIC_DISTR_OFFSET) + 0x200)
+#define GICD_ISPENDINGR0            ((GICD_ISPENDINGR_OFFSET) + 0x00)
+#define GICD_ISPENDINGR1            ((GICD_ISPENDINGR_OFFSET) + 0x04)
+#define GICD_ISPENDINGR2            ((GICD_ISPENDINGR_OFFSET) + 0x08)
+#define GICD_ISPENDINGR3            ((GICD_ISPENDINGR_OFFSET) + 0x0C)
+#define GICD_ISPENDINGR4            ((GICD_ISPENDINGR_OFFSET) + 0x10)
+#define GICD_ISPENDINGR5            ((GICD_ISPENDINGR_OFFSET) + 0x14)
+#define GICD_ISPENDINGR6            ((GICD_ISPENDINGR_OFFSET) + 0x18)
+#define GICD_ISPENDINGR7            ((GICD_ISPENDINGR_OFFSET) + 0x1C)
+#define GICD_ITARGETSR_OFFSET       ((GIC_DISTR_OFFSET) + 0x800)
+#define GICD_ITARGETSR0             ((GICD_ITARGETSR_OFFSET) + 0x00)
+#define GICD_ITARGETSR1             ((GICD_ITARGETSR_OFFSET) + 0x04)
+#define GICD_ITARGETSR2             ((GICD_ITARGETSR_OFFSET) + 0x08)
+#define GICD_ITARGETSR3             ((GICD_ITARGETSR_OFFSET) + 0x0C)
+#define GICD_ITARGETSR4             ((GICD_ITARGETSR_OFFSET) + 0x10)
+#define GICD_ITARGETSR5             ((GICD_ITARGETSR_OFFSET) + 0x14)
+#define GICD_ITARGETSR6             ((GICD_ITARGETSR_OFFSET) + 0x18)
+#define GICD_ITARGETSR7             ((GICD_ITARGETSR_OFFSET) + 0x1C)
+#define GICD_ITARGETSR8             ((GICD_ITARGETSR_OFFSET) + 0x20)
+#define GICD_ITARGETSR9             ((GICD_ITARGETSR_OFFSET) + 0x24)
+#define GICD_ITARGETSR10            ((GICD_ITARGETSR_OFFSET) + 0x28)
+#define GICD_ITARGETSR11            ((GICD_ITARGETSR_OFFSET) + 0x2C)
+#define GICD_ITARGETSR12            ((GICD_ITARGETSR_OFFSET) + 0x30)
+#define GICD_ITARGETSR13            ((GICD_ITARGETSR_OFFSET) + 0x34)
+#define GICD_ITARGETSR14            ((GICD_ITARGETSR_OFFSET) + 0x38)
+#define GICD_ITARGETSR15            ((GICD_ITARGETSR_OFFSET) + 0x3C)
+#define GICD_ITARGETSR16            ((GICD_ITARGETSR_OFFSET) + 0x40)
+#define GICD_ITARGETSR17            ((GICD_ITARGETSR_OFFSET) + 0x44)
+#define GICD_ITARGETSR18            ((GICD_ITARGETSR_OFFSET) + 0x48)
+#define GICD_ITARGETSR19            ((GICD_ITARGETSR_OFFSET) + 0x4C)
+#define GICD_ITARGETSR20            ((GICD_ITARGETSR_OFFSET) + 0x50)
+#define GICD_ITARGETSR21            ((GICD_ITARGETSR_OFFSET) + 0x54)
+#define GICD_ITARGETSR22            ((GICD_ITARGETSR_OFFSET) + 0x58)
+#define GICD_ITARGETSR23            ((GICD_ITARGETSR_OFFSET) + 0x5C)
+#define GICD_ITARGETSR24            ((GICD_ITARGETSR_OFFSET) + 0x60)
+#define GICD_ITARGETSR25            ((GICD_ITARGETSR_OFFSET) + 0x64)
+#define GICD_ITARGETSR26            ((GICD_ITARGETSR_OFFSET) + 0x68)
+#define GICD_ITARGETSR27            ((GICD_ITARGETSR_OFFSET) + 0x6C)
+#define GICD_SGIR                   ((GIC_DISTR_OFFSET) + 0xF00)
+#define GIC_CPUIFACE_OFFSET         ((GIC_BASE_REG) + 0x2000)
+#define GICC_CTLR                   ((GIC_CPUIFACE_OFFSET) + 0x00)
+#define GICC_PMR                    ((GIC_CPUIFACE_OFFSET) + 0x04)
+#define GICC_IAR                    ((GIC_CPUIFACE_OFFSET) + 0x0C)
+#define GICC_EOIR                   ((GIC_CPUIFACE_OFFSET) + 0x10)
+
+#endif

--- a/chapter2/code3/arch/arm64/board/raspberry-pi-4/include/board/peripheral.h
+++ b/chapter2/code3/arch/arm64/board/raspberry-pi-4/include/board/peripheral.h
@@ -1,0 +1,22 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _BOARD_PERIPHERAL_H
+#define _BOARD_PERIPHERAL_H
+
+#define MAIN_PERIPH_BASE             (0x47C000000)
+#define LOCAL_PERIPH_BASE            (0x4C0000000)
+#define GIC_BASE                     ((LOCAL_PERIPH_BASE) + 0x00040000)
+
+#endif

--- a/chapter2/code3/arch/arm64/board/raspberry-pi-4/irq.S
+++ b/chapter2/code3/arch/arm64/board/raspberry-pi-4/irq.S
@@ -1,0 +1,61 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "arch/linux-extension.h"
+#include "board/devio.h"
+#include "board/gic.h"
+
+.globl __irq_acknowledge
+__irq_acknowledge:
+    __MOV_Q         x0, GICC_IAR
+    __DEV_READ_32   w0, x0
+    ret
+
+.globl __irq_end
+__irq_end:
+    __MOV_Q         x1, GICC_EOIR
+    __DEV_WRITE_32  w0, x1
+    isb
+    ret
+
+.globl __irq_enable_spid
+__irq_enable_spid:
+    mov             x13, #5
+    lsr             x1, x0, x13
+    mov             x13, #2
+    lsl             x1, x1, x13
+    __MOV_Q         x3, GICD_ISENABLER_OFFSET
+    add             x3, x3, x1
+    and             w2, w0, #0x1f
+    mov             x0, #1
+    lsl             w2, w0, w2
+    __DEV_WRITE_32  w2, x3
+    isb
+    ret
+
+.globl __irq_target_cpumask
+__irq_target_cpumask:
+    mov             w3, #3
+    and             w3, w0, w3 //x3 = spid offset
+    lsl             w3, w3, #3
+    lsl             w1, w1, w3 // w1 = val to write
+    mov             w3, #~(3)
+    and             w2, w0, w3 //x3 = spid & mask
+    __MOV_Q         x3, GICD_ITARGETSR_OFFSET
+    add             x3, x3, x2 // x3 = base
+    __DEV_READ_32   w4, x3
+    orr             w4, w4, w1
+    __DEV_WRITE_32  w4, x3
+    isb
+    ret

--- a/chapter2/code3/arch/arm64/board/raspberry-pi-4/irq.c
+++ b/chapter2/code3/arch/arm64/board/raspberry-pi-4/irq.c
@@ -1,0 +1,68 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cake/log.h"
+#include "board/bare-metal.h"
+#include "board/gic.h"
+
+#define SPID_TIMER3     (0x63)
+
+struct irq_read_val {
+    unsigned int irqid: 10;
+    unsigned long cpuid: 3;
+    unsigned long reserved: 19;
+};
+
+extern unsigned int  __irq_acknowledge();
+extern void __irq_enable_spid(unsigned long spid);
+extern void __irq_end(unsigned int irq);
+extern void __irq_target_cpumask(unsigned long spid, unsigned long mask);
+extern void timer_interrupt();
+
+static void enable_irq_target_cpu()
+{
+    __irq_target_cpumask(SPID_TIMER3, CPU0_MASK);
+}
+
+void handle_irq()
+{
+    do {
+        unsigned int irq = __irq_acknowledge();
+        struct irq_read_val *irqrv = (struct irq_read_val *) &irq;
+        if(irqrv->irqid < 1020) {
+            __irq_end(irq);
+            switch(irqrv->irqid) {
+                case SPID_TIMER3:
+                    timer_interrupt();
+                    break;
+                default:
+                    log("Encountered Undefined Interrupt: %x\r\n");
+            }
+        }
+        else {
+            break;
+        }
+    } while(1);
+}
+
+static void init_irq_registers()
+{
+    __irq_enable_spid(SPID_TIMER3);
+}
+
+void irq_init()
+{
+    init_irq_registers();
+    enable_irq_target_cpu();
+}

--- a/chapter2/code3/arch/arm64/board/raspberry-pi-4/mini-uart.S
+++ b/chapter2/code3/arch/arm64/board/raspberry-pi-4/mini-uart.S
@@ -1,0 +1,36 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "arch/linux-extension.h"
+#include "board/devio.h"
+#include "board/peripheral.h"
+
+#define UART_BASE_REG           (MAIN_PERIPH_BASE + 0x2215000)
+#define AUX_MU_IO_REG           ((UART_BASE_REG) + 0x40)
+#define AUX_MU_LSR_REG          ((UART_BASE_REG) + 0x54)
+#define AUX_MU_LSR_REG_TISHIFT  (6)
+#define AUX_MU_LSR_REG_TIFLAG   (1 << (AUX_MU_LSR_REG_TISHIFT))
+
+.globl __uart_can_io
+__uart_can_io:
+    __MOV_Q         x0, AUX_MU_LSR_REG
+    __DEV_READ_32   w0, x0
+    and             w0, w0, AUX_MU_LSR_REG_TIFLAG
+    ret
+
+.globl __uart_putchar
+__uart_putchar:
+    __MOV_Q         x1, AUX_MU_IO_REG
+    __DEV_WRITE_8   w0, x1
+    ret

--- a/chapter2/code3/arch/arm64/board/raspberry-pi-4/mini-uart.c
+++ b/chapter2/code3/arch/arm64/board/raspberry-pi-4/mini-uart.c
@@ -1,0 +1,49 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cake/log.h"
+
+extern int  __uart_can_io();
+extern void __uart_putchar(char c);
+
+static void uart_puts(char *s);
+static struct console console = {
+    .write = uart_puts
+};
+
+static inline int check_ready()
+{
+    return __uart_can_io();
+}
+
+static inline void uart_putchar(char c)
+{
+    while(!check_ready()) {
+    }
+    return __uart_putchar(c);
+}
+
+void console_init()
+{
+    register_console(&console);
+}
+
+static void uart_puts(char *s)
+{
+    if(s) {
+        for(char *str = s; *str != '\0'; str++) {
+            uart_putchar(*str);
+        }
+    }
+}

--- a/chapter2/code3/arch/arm64/board/raspberry-pi-4/secure_boot.S
+++ b/chapter2/code3/arch/arm64/board/raspberry-pi-4/secure_boot.S
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2016-2019 Raspberry Pi (Trading) Ltd.
+ * Copyright (c) 2016 Stephen Warren <swarren@wwwdotorg.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * * Neither the name of the copyright holder nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "arch/bare-metal.h"
+#include "arch/linux-extension.h"
+#include "board/devio.h"
+#include "board/gic.h"
+
+#define LOCAL_CONTROL       0x4c0000000
+#define LOCAL_PRESCALER     0x4c0000008
+
+#define OSC_FREQ            54000000
+
+#define L2CTLR_EL1          s3_1_c11_c0_2
+#define L2CTLR_EL1_VALUE    0b00100010
+
+#define CPUECTLR_EL1        s3_1_c15_c2_1
+#define CPUECTLR_EL1_SMPEN  SET_BIT(6)
+
+#define ACTLR_EL3_VALUE     (SET_BIT(6) | \
+                             SET_BIT(5) | \
+                             SET_BIT(4) | \
+                             SET_BIT(1) | \
+                             SET_BIT(0))
+
+#define SCR_EL3_RW          SET_BIT(10)
+#define SCR_EL3_SMD         SET_BIT(7)
+#define SCR_EL3_RES1_5      SET_BIT(5)
+#define SCR_EL3_RES1_4      SET_BIT(4)
+#define SCR_EL3_NS          SET_BIT(0)
+#define SCR_EL3_VALUE       (SCR_EL3_RW | \
+                             SCR_EL3_SMD | \
+                             SCR_EL3_RES1_5 | \
+                             SCR_EL3_RES1_4 | \
+                             SCR_EL3_NS)
+
+#define SPSR_EL3_D          SET_BIT(9)
+#define SPSR_EL3_A          SET_BIT(8)
+#define SPSR_EL3_I          SET_BIT(7)
+#define SPSR_EL3_F          SET_BIT(6)
+#define SPSR_EL3_EL1h       0b0101
+#define SPSR_EL3_VALUE      (SPSR_EL3_D | \
+                             SPSR_EL3_A | \
+                             SPSR_EL3_I | \
+                             SPSR_EL3_F | \
+                             SPSR_EL3_EL1h)
+
+#define HCR_EL2_RW          SET_BIT(31)
+#define HCR_EL2_VALUE       HCR_EL2_RW
+
+#define SCTLR_EL1_RES1_29   SET_BIT(29)
+#define SCTLR_EL1_RES1_28   SET_BIT(28)
+#define SCTLR_EL1_RES1_23   SET_BIT(23)
+#define SCTLR_EL1_RES1_22   SET_BIT(22)
+#define SCTLR_EL1_RES1_20   SET_BIT(20)
+#define SCTLR_EL1_RES1_11   SET_BIT(11)
+#define SCTLR_EL1_VALUE     (SCTLR_EL1_RES1_29 | \
+                             SCTLR_EL1_RES1_28 | \
+                             SCTLR_EL1_RES1_23 | \
+                             SCTLR_EL1_RES1_22 | \
+                             SCTLR_EL1_RES1_20 | \
+                             SCTLR_EL1_RES1_11)
+
+.section ".text.boot"
+
+.globl __secure_board_specific_setup
+__secure_board_specific_setup:
+    mov     x28, x30
+    bl      __setup_local_control
+    bl      __setup_cortex_a72_regs
+    bl      __setup_arm_arch_regs
+    bl      __setup_gic
+    mov     x30, x28
+    ret
+
+__setup_local_control:
+    ldr     x0, =LOCAL_CONTROL
+    str     wzr, [x0]
+    mov     w1, 0x80000000
+    str     w1, [x0, #(LOCAL_PRESCALER - LOCAL_CONTROL)]
+    dsb     sy
+    isb
+    ret
+
+__setup_cortex_a72_regs:
+    mrs     x0, L2CTLR_EL1
+    mov     x1, L2CTLR_EL1_VALUE
+    orr     x0, x0, x1
+    msr     L2CTLR_EL1, x0
+    mov     x0, #CPUECTLR_EL1_SMPEN
+    msr     CPUECTLR_EL1, x0
+    ldr     x0, =OSC_FREQ
+    msr     cntfrq_el0, x0
+    msr     cntvoff_el2, xzr
+    mov     x0, 0x33ff
+    msr     cptr_el3, x0
+    mov     x0, #ACTLR_EL3_VALUE
+    msr     actlr_el3, x0
+    dsb     sy
+    isb
+    ret
+
+__setup_arm_arch_regs:
+    ldr     x0, =SCR_EL3_VALUE
+    msr     scr_el3, x0
+    ldr     x0, =HCR_EL2_VALUE
+    msr     hcr_el2, x0
+    ldr     x0, =SCTLR_EL1_VALUE
+    msr     sctlr_el1, x0
+    ldr     x0, =SPSR_EL3_VALUE
+    msr     spsr_el3, x0
+    dsb     sy
+    isb
+    ret
+
+__setup_gic:
+    mrs             x0, mpidr_el1
+    tst             x0, #3
+    __MOV_Q         x2, GICD_IGROUPR_OFFSET
+    b.ne            2f
+    mov             w0, #3
+    __MOV_Q         x1, GICD_CTLR
+    __DEV_WRITE_32  w0, x1
+    mov             w0, #~(0)
+    mov             w1, #(7 * 4)
+1:
+    subs            w1, w1, #4
+    add             x3, x2, x1
+    __DEV_WRITE_32  w0, x3
+    b.ne            1b
+2:
+    mov             w0, #~(0)
+    __DEV_WRITE_32  w0, x2
+    mov             w0, #0x1e7
+    __MOV_Q         x1, GICC_CTLR
+    __DEV_WRITE_32  w0, x1
+    mov             w0, #0xFF
+    __MOV_Q         x1, GICC_PMR
+    __DEV_WRITE_32  w0, x1
+    dsb             sy
+    isb
+    ret
+

--- a/chapter2/code3/arch/arm64/board/raspberry-pi-4/timer.S
+++ b/chapter2/code3/arch/arm64/board/raspberry-pi-4/timer.S
@@ -1,0 +1,45 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "arch/linux-extension.h"
+#include "board/devio.h"
+#include "board/peripheral.h"
+
+#define TIMER_BASE_REG  (MAIN_PERIPH_BASE + 0x2003000)
+#define TIMER_CS        ((TIMER_BASE_REG) + 0x0)
+#define TIMER_CLO       ((TIMER_BASE_REG) + 0x4)
+#define TIMER_C3        ((TIMER_BASE_REG) + 0x18)
+
+#define TIMER_CHANNEL   (3)
+#define TIMER_CS_M3     (1 << (TIMER_CHANNEL))
+
+.globl __timer_clock_low
+__timer_clock_low:
+    __MOV_Q         x0, TIMER_CLO
+    __DEV_READ_32   w0, x0
+    ret
+
+.globl __timer_control_reset
+__timer_control_reset:
+    mov             w0, TIMER_CS_M3
+    __MOV_Q         x1, TIMER_CS
+    __DEV_WRITE_32  w0, x1
+    ret
+
+.globl __timer_set_compare
+__timer_set_compare:
+    __MOV_Q         x1, TIMER_C3
+    __DEV_WRITE_32  w0, x1
+    ret
+

--- a/chapter2/code3/arch/arm64/board/raspberry-pi-4/timer.c
+++ b/chapter2/code3/arch/arm64/board/raspberry-pi-4/timer.c
@@ -1,0 +1,34 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define INTERRUPT_INTERVAL  (1000000)
+
+extern unsigned int __timer_clock_low();
+extern void __timer_control_reset();
+extern void __timer_set_compare(unsigned int compare);
+
+static unsigned int current;
+
+void timer_init()
+{
+    current = __timer_clock_low();
+    current += INTERRUPT_INTERVAL;
+    __timer_set_compare(current);
+}
+
+void timer_interrupt()
+{
+    timer_init();
+    __timer_control_reset();
+}

--- a/chapter2/code3/arch/arm64/entry.S
+++ b/chapter2/code3/arch/arm64/entry.S
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2012 ARM Ltd.
+ * Authors:     Catalin Marinas <catalin.marinas@arm.com>
+ *              Will Deacon <will.deacon@arm.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "exec/asm-offsets.h"
+
+#define INVALID_SYNC_EL1T       (0)
+#define INVALID_IRQ_EL1T        (1)
+#define INVALID_FIQ_EL1T        (2)
+#define INVALID_ERROR_EL1T      (3)
+#define INVALID_SYNC_EL1H       (4)
+#define INVALID_IRQ_EL1H        (5)
+#define INVALID_FIQ_EL1H        (6)
+#define INVALID_ERROR_EL1H      (7)
+#define INVALID_SYNC_EL0_64     (8)
+#define INVALID_IRQ_EL0_64      (9)
+#define INVALID_FIQ_EL0_64      (10)
+#define INVALID_ERROR_EL0_64    (11)
+#define INVALID_SYNC_EL0_32     (12)
+#define INVALID_IRQ_EL0_32      (13)
+#define INVALID_FIQ_EL0_32      (14)
+#define INVALID_ERROR_EL0_32    (15)
+
+    .macro __HANDLE_INVALID_ENTRY, idx
+        mov     x0, \idx
+        bl      log_invalid_exception
+        b       __exception_hang
+    .endm
+
+    .macro __VECTABLE_ENTRY, label
+        .align 7
+        b \ label
+    .endm
+
+    .macro __ENTRY_SAVE
+        sub     sp, sp, #STRUCT_STACK_SAVE_REGISTERS_SIZE
+        stp     x0, x1, [sp, #16 * 0]
+        stp     x2, x3, [sp, #16 * 1]
+        stp     x4, x5, [sp, #16 * 2]
+        stp     x6, x7, [sp, #16 * 3]
+        stp     x8, x9, [sp, #16 * 4]
+        stp     x10, x11, [sp, #16 * 5]
+        stp     x12, x13, [sp, #16 * 6]
+        stp     x14, x15, [sp, #16 * 7]
+        stp     x16, x17, [sp, #16 * 8]
+        stp     x18, x19, [sp, #16 * 9]
+        stp     x20, x21, [sp, #16 * 10]
+        stp     x22, x23, [sp, #16 * 11]
+        stp     x24, x25, [sp, #16 * 12]
+        stp     x26, x27, [sp, #16 * 13]
+        stp     x28, x29, [sp, #16 * 14]
+        add     x21, sp, #STRUCT_STACK_SAVE_REGISTERS_SIZE
+        mrs     x22, elr_el1
+        mrs     x23, spsr_el1
+        stp     x30, x21, [sp, #16 * 15]
+        stp     x22, x23, [sp, #16 * 16]
+    .endm
+
+    .macro __ENTRY_RESTORE
+        ldp     x22, x23, [sp, #16 * 16]
+        msr     elr_el1, x22
+        msr     spsr_el1, x23
+        ldp     x0, x1, [sp, #16 * 0]
+        ldp     x2, x3, [sp, #16 * 1]
+        ldp     x4, x5, [sp, #16 * 2]
+        ldp     x6, x7, [sp, #16 * 3]
+        ldp     x8, x9, [sp, #16 * 4]
+        ldp     x10, x11, [sp, #16 * 5]
+        ldp     x12, x13, [sp, #16 * 6]
+        ldp     x14, x15, [sp, #16 * 7]
+        ldp     x16, x17, [sp, #16 * 8]
+        ldp     x18, x19, [sp, #16 * 9]
+        ldp     x20, x21, [sp, #16 * 10]
+        ldp     x22, x23, [sp, #16 * 11]
+        ldp     x24, x25, [sp, #16 * 12]
+        ldp     x26, x27, [sp, #16 * 13]
+        ldp     x28, x29, [sp, #16 * 14]
+        ldp     x30, xzr, [sp, #16 * 15]
+        add     sp, sp, #STRUCT_STACK_SAVE_REGISTERS_SIZE
+        eret
+    .endm
+
+__exception_hang:
+    wfe
+    b   __exception_hang
+
+.align 11
+.global vectors
+vectors:
+    __VECTABLE_ENTRY    sync_el1t
+    __VECTABLE_ENTRY    irq_el1t
+    __VECTABLE_ENTRY    fiq_el1t
+    __VECTABLE_ENTRY    error_el1t
+    __VECTABLE_ENTRY    sync_el1h
+    __VECTABLE_ENTRY    irq_el1h
+    __VECTABLE_ENTRY    fiq_el1h
+    __VECTABLE_ENTRY    error_el1h
+    __VECTABLE_ENTRY    sync_el0_64
+    __VECTABLE_ENTRY    irq_el0_64
+    __VECTABLE_ENTRY    fiq_el0_64
+    __VECTABLE_ENTRY    error_el0_64
+    __VECTABLE_ENTRY    sync_el0_32
+    __VECTABLE_ENTRY    irq_el0_32
+    __VECTABLE_ENTRY    fiq_el0_32
+    __VECTABLE_ENTRY    error_el0_32
+
+sync_el1t:
+    __HANDLE_INVALID_ENTRY  INVALID_SYNC_EL1T
+
+irq_el1t:
+    __HANDLE_INVALID_ENTRY  INVALID_IRQ_EL1T
+
+fiq_el1t:
+    __HANDLE_INVALID_ENTRY  INVALID_FIQ_EL1T
+
+error_el1t:
+    __HANDLE_INVALID_ENTRY  INVALID_ERROR_EL1T
+
+sync_el1h:
+    __HANDLE_INVALID_ENTRY  INVALID_SYNC_EL1H
+
+irq_el1h:
+    __ENTRY_SAVE
+    bl  handle_irq
+    __ENTRY_RESTORE
+
+fiq_el1h:
+    __HANDLE_INVALID_ENTRY  INVALID_FIQ_EL1H
+
+error_el1h:
+    __HANDLE_INVALID_ENTRY  INVALID_ERROR_EL1H
+
+sync_el0_64:
+    __HANDLE_INVALID_ENTRY  INVALID_SYNC_EL0_64
+
+irq_el0_64:
+    __HANDLE_INVALID_ENTRY  INVALID_IRQ_EL0_64
+
+fiq_el0_64:
+    __HANDLE_INVALID_ENTRY  INVALID_FIQ_EL0_64
+
+error_el0_64:
+    __HANDLE_INVALID_ENTRY  INVALID_ERROR_EL0_64
+
+sync_el0_32:
+    __HANDLE_INVALID_ENTRY  INVALID_SYNC_EL0_32
+
+irq_el0_32:
+    __HANDLE_INVALID_ENTRY  INVALID_IRQ_EL0_32
+
+fiq_el0_32:
+    __HANDLE_INVALID_ENTRY  INVALID_FIQ_EL0_32
+
+error_el0_32:
+    __HANDLE_INVALID_ENTRY  INVALID_ERROR_EL0_32

--- a/chapter2/code3/arch/arm64/error.c
+++ b/chapter2/code3/arch/arm64/error.c
@@ -1,0 +1,40 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cake/log.h"
+
+const char *error_messages[] = {
+    "INVALID_SYNC_EL1T",
+    "INVALID_IRQ_EL1T",
+    "INVALID_FIQ_EL1T",
+    "INVALID_ERROR_EL1T",
+    "INVALID_SYNC_EL1H",
+    "INVALID_IRQ_EL1H",
+    "INVALID_FIQ_EL1H",
+    "INVALID_ERROR_EL1H",
+    "INVALID_SYNC_EL0_64",
+    "INVALID_IRQ_EL0_64",
+    "INVALID_FIQ_EL0_64",
+    "INVALID_ERROR_EL0_64",
+    "INVALID_SYNC_EL0_32",
+    "INVALID_IRQ_EL0_32",
+    "INVALID_FIQ_EL0_32",
+    "INVALID_ERROR_EL0_32"
+};
+
+void log_invalid_exception(int idx)
+{
+    const char *message = error_messages[idx];
+    log("Encountered Invalid Exception Entry: %s\r\n", message);
+}

--- a/chapter2/code3/arch/arm64/exec/asm-offsets.c
+++ b/chapter2/code3/arch/arm64/exec/asm-offsets.c
@@ -1,0 +1,28 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+#include "arch/process.h"
+
+int main()
+{
+    printf("#ifndef _EXEC_ASM_OFFSETS_H\n");
+    printf("#define _EXEC_ASM_OFFSETS_H\n");
+    printf("\n");
+    printf("#define %s \t\t\t%lu\n", "STRUCT_STACK_SAVE_REGISTERS_SIZE", sizeof(struct stack_save_registers));
+    printf("\n");
+    printf("#endif\n");
+    return 0;
+}
+

--- a/chapter2/code3/arch/arm64/include/arch/bare-metal.h
+++ b/chapter2/code3/arch/arm64/include/arch/bare-metal.h
@@ -1,0 +1,20 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _ARCH_BARE_METAL_H
+#define _ARCH_BARE_METAL_H
+
+#define SET_BIT(pos)                (1 << (pos))
+
+#endif

--- a/chapter2/code3/arch/arm64/include/arch/irq.h
+++ b/chapter2/code3/arch/arm64/include/arch/irq.h
@@ -1,0 +1,26 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _ARCH_IRQ_H
+#define _ARCH_IRQ_H
+
+#define IRQ_DISABLE         __irq_disable
+#define IRQ_ENABLE          __irq_enable
+#define WAIT_FOR_INTERRUPT  __wait_for_interrupt
+
+extern void __irq_disable();
+extern void __irq_enable();
+extern void __wait_for_interrupt();
+
+#endif

--- a/chapter2/code3/arch/arm64/include/arch/linux-extension.h
+++ b/chapter2/code3/arch/arm64/include/arch/linux-extension.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 1996-2000 Russell King
+ * Copyright (C) 2012 ARM Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _ARCH_LINUX_EXTENSION_H
+#define _ARCH_LINUX_EXTENSION_H
+
+    .macro __MOV_Q, reg, val
+        .if     (((\val) >> 31) == 0 || ((\val) >> 31) == 0x1ffffffff)
+        movz    \reg, :abs_g1_s:\val
+        .else
+        .if     (((\val) >> 47) == 0 || ((\val) >> 47) == 0x1ffff)
+        movz    \reg, :abs_g2_s:\val
+        .else
+        movz    \reg, :abs_g3:\val
+        movk    \reg, :abs_g2_nc:\val
+        .endif
+        movk    \reg, :abs_g1_nc:\val
+        .endif
+        movk    \reg, :abs_g0_nc:\val
+    .endm
+
+    .macro  __ADR_L, dst, sym
+        adrp    \dst, \sym
+        add     \dst, \dst, :lo12:\sym
+    .endm
+
+#endif

--- a/chapter2/code3/arch/arm64/include/arch/process.h
+++ b/chapter2/code3/arch/arm64/include/arch/process.h
@@ -1,0 +1,27 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _ARCH_PROCESS_H
+#define _ARCH_PROCESS_H
+
+#include "cake/types.h"
+
+struct stack_save_registers {
+    u64  regs[31];
+    u64  sp;
+    u64  pc;
+    u64  pstate;
+};
+
+#endif

--- a/chapter2/code3/arch/arm64/irq.S
+++ b/chapter2/code3/arch/arm64/irq.S
@@ -1,0 +1,30 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.global __irq_disable
+__irq_disable:
+    msr     daifset, #2
+    ret
+
+.globl __irq_enable
+__irq_enable:
+    msr     daifclr, #2
+    ret
+
+.global __wait_for_interrupt
+__wait_for_interrupt:
+    wfi
+    dsb     sy
+    isb
+    ret

--- a/chapter2/code3/arch/arm64/linker.ld
+++ b/chapter2/code3/arch/arm64/linker.ld
@@ -1,0 +1,19 @@
+OUTPUT_ARCH(aarch64)
+ENTRY(_start)
+SECTIONS
+{
+    . = 0x0;
+    .text.boot : {
+        _start = .;
+        *(.text.boot)
+    }
+    .text : { *(.text) }
+    .rodata : { *(.rodata) }
+    .data : { *(.data) }
+    . = ALIGN(0x8);
+    bss_begin = .;
+    .bss : { *(.bss*) }
+    bss_end = .;
+    . = 0x400000;
+    _end = .;
+}

--- a/chapter2/code3/arch/arm64/main.S
+++ b/chapter2/code3/arch/arm64/main.S
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 1994-2002 Russell King
+ * Copyright (C) 2003-2012 ARM Ltd.
+ * Authors: Catalin Marinas <catalin.marinas@arm.com>
+ *      Will Deacon <will.deacon@arm.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "arch/linux-extension.h"
+
+.section ".text.boot"
+
+.globl __entry
+__entry:
+    msr     daifset, 0b1111
+    bl      __secure_board_specific_setup
+    adr     x0, __el1entry
+    msr     elr_el3, x0
+    eret
+
+__el1entry:
+    mrs     x0, mpidr_el1
+    and     x0, x0, #0xFF
+    cbz     x0, __run
+    b       __sleep
+
+__sleep:
+    wfe
+    b       __sleep
+
+__run:
+    __ADR_L     x0, vectors
+    msr         vbar_el1, x0
+    adrp        x13, _end
+    mov         sp, x13
+    adr         x0, bss_begin
+    adr         x1, bss_end
+    bl          __zerobss
+    bl          cheesecake_main
+    b           __sleep
+
+__zerobss:
+    sub     x1, x1, x0
+    str     xzr, [x0], #8
+    subs    x1, x1, #8
+    b.gt    __zerobss
+    ret

--- a/chapter2/code3/build.sh
+++ b/chapter2/code3/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+if [[ $1 == "clean" ]]; then
+    docker run --rm -v $(pwd):/ccos4rbpi -w /ccos4rbpi -u $(id -u ) ccos4rbpi make clean
+else
+    docker run --rm -v $(pwd):/ccos4rbpi -w /ccos4rbpi -u $(id -u ) ccos4rbpi make exec ARCH=arm64
+    docker run --rm -v $(pwd):/ccos4rbpi -w /ccos4rbpi -u $(id -u ) ccos4rbpi make ARCH=arm64 BOARD=raspberry-pi-4
+fi

--- a/chapter2/code3/include/cake/log.h
+++ b/chapter2/code3/include/cake/log.h
@@ -1,0 +1,25 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _CAKE_LOG_H
+#define _CAKE_LOG_H
+
+struct console {
+    void (*write)(char *s);
+};
+
+void log(char *fmt, ...);
+void register_console(struct console *c);
+
+#endif

--- a/chapter2/code3/include/cake/string.h
+++ b/chapter2/code3/include/cake/string.h
@@ -1,0 +1,20 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _CAKE_STRING_H
+#define _CAKE_STRING_H
+
+void xintos(unsigned x, char *t);
+
+#endif

--- a/chapter2/code3/include/cake/types.h
+++ b/chapter2/code3/include/cake/types.h
@@ -1,0 +1,39 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _CAKE_TYPES_H
+#define _CAKE_TYPES_H
+
+typedef __signed__ char __s8;
+typedef unsigned char __u8;
+
+typedef __signed__ short __s16;
+typedef unsigned short __u16;
+
+typedef __signed__ int __s32;
+typedef unsigned int __u32;
+
+__extension__ typedef __signed__ long long __s64;
+__extension__ typedef unsigned long long __u64;
+
+typedef __s8  s8;
+typedef __u8  u8;
+typedef __s16 s16;
+typedef __u16 u16;
+typedef __s32 s32;
+typedef __u32 u32;
+typedef __s64 s64;
+typedef __u64 u64;
+
+#endif

--- a/chapter2/code3/src/cheesecake.c
+++ b/chapter2/code3/src/cheesecake.c
@@ -1,0 +1,46 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cake/log.h"
+#include "arch/irq.h"
+
+extern void irq_init();
+extern void log_init();
+extern void timer_init();
+void init();
+
+void cheesecake_main(void)
+{
+    unsigned long count = 1;
+    char *version = "0.2.7";
+    init();
+    log("Hello, Cheesecake!\r\n");
+    IRQ_ENABLE();
+    while (1) {
+        log("Version: %s\r\n", version);
+        log("Message count: %x\r\n", count++);
+        log("\r\n");
+        WAIT_FOR_INTERRUPT();
+    }
+}
+
+void init()
+{
+    log_init();
+    log("LOG MODULE INITIALIZED\r\n");
+    irq_init();
+    log("IRQ MODULE INITIALIZED\r\n");
+    timer_init();
+    log("TIMER MODULE INITIALIZED\r\n");
+}

--- a/chapter2/code3/src/log.c
+++ b/chapter2/code3/src/log.c
@@ -1,0 +1,138 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdarg.h>
+#include "cake/types.h"
+#include "cake/log.h"
+#include "cake/string.h"
+
+#define BUFFER_SIZE                     (255)
+#define MAX_BUFFER_DATA_FOR_NULL_TERM   (BUFFER_SIZE - 1)
+
+struct writebuf {
+    u8 pos;
+    char s[BUFFER_SIZE];
+};
+
+static void flush(struct writebuf *w);
+static int puthex(unsigned long x, struct writebuf *w);
+static int putstr(char *s, struct writebuf *w);
+
+extern void console_init();
+
+static struct console *console;
+
+static int check_flush(struct writebuf *w)
+{
+    if(w->pos == MAX_BUFFER_DATA_FOR_NULL_TERM) {
+        flush(w);
+        return 1;
+    }
+    return 0;
+}
+
+static void cleanbuf(struct writebuf *w)
+{
+    w->pos = 0;
+    for(unsigned int i = 0; i < BUFFER_SIZE; i++) {
+        w->s[i] = 0;
+    }
+}
+
+static void flush(struct writebuf *w)
+{
+    if(w->pos) {
+        console->write(w->s);
+    }
+}
+
+void log(char *fmt, ...)
+{
+    char c;
+    va_list va;
+    va_start(va, fmt);
+    struct writebuf w;
+    cleanbuf(&w);
+    while((c = *(fmt++)) != '\0') {
+        if(c != '%') {
+            w.s[w.pos++] = c;
+            if(check_flush(&w)) {
+                va_end(va);
+                return;
+            }
+        }
+        else {
+            int ret;
+            c = *(fmt++);
+            switch(c)
+            {
+                case 's':
+                    ret = putstr(va_arg(va, char*), &w);
+                    if(ret) {
+                        va_end(va);
+                        return;
+                    }
+                    break;
+                case 'x':
+                    ret = puthex(va_arg(va, unsigned long), &w);
+                    if(ret) {
+                        va_end(va);
+                        return;
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+    flush(&w);
+    va_end(va);
+}
+
+void log_init()
+{
+    console_init();
+}
+
+static int puthex(unsigned long x, struct writebuf *w)
+{
+    char c;
+    int d = 0;
+    char temp[27];
+    xintos(x, temp);
+    while((c = temp[d++]) != '\0') {
+        w->s[w->pos++] = c;
+        if(check_flush(w)) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int putstr(char *s, struct writebuf *w)
+{
+    char c;
+    while((c = *s++)  != '\0') {
+        w->s[w->pos++] = c;
+        if(check_flush(w)) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+void register_console(struct console *c)
+{
+    console = c;
+}

--- a/chapter2/code3/src/string.c
+++ b/chapter2/code3/src/string.c
@@ -1,0 +1,36 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+void xintos(unsigned long x, char *t)
+{
+    int temp_size = 0;
+    char c, temp[16];
+    *(t++) = '0';
+    *(t++) = 'x';
+    do {
+        c = x % 16;
+        if(c < 10) {
+            c = c + 0x30;
+        } else {
+            c = c + 0x37;
+        }
+        temp[temp_size++] = c;
+        x /= 16;
+    } while(x);
+    while(temp_size--) {
+        *(t++) = temp[temp_size];
+    }
+    *(t++) = '\0';
+    return;
+}


### PR DESCRIPTION
Problem:
---
- First IRQ to work with is the timer interrupt
- It needs initialization

Solution:
---
- Use system timer 3 with SPID 99
- Add memory barriers around device reads/writes

Issue: #41