### PR TITLE
:bug: Fix SMP ID Mask

### DIFF
--- a/chapter1/code0/src/main.S
+++ b/chapter1/code0/src/main.S
@@ -17,12 +17,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#define MPIDR_HWID_MASK_LITE    0xFFFFFF
+
 .section ".text.boot"
 
 .globl __entry
 __entry:
     mrs     x0, mpidr_el1
-    and     x0, x0, #0xFF
+    and     x0, x0, #MPIDR_HWID_MASK_LITE
     cbz     x0, __run
     b       __sleep
 

--- a/chapter1/code1/arch/arm64/main.S
+++ b/chapter1/code1/arch/arm64/main.S
@@ -17,12 +17,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#define MPIDR_HWID_MASK_LITE    0xFFFFFF
+
 .section ".text.boot"
 
 .globl __entry
 __entry:
     mrs     x0, mpidr_el1
-    and     x0, x0, #0xFF
+    and     x0, x0, #MPIDR_HWID_MASK_LITE
     cbz     x0, __run
     b       __sleep
 

--- a/chapter1/code2/arch/arm64/main.S
+++ b/chapter1/code2/arch/arm64/main.S
@@ -17,12 +17,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#define MPIDR_HWID_MASK_LITE    0xFFFFFF
+
 .section ".text.boot"
 
 .globl __entry
 __entry:
     mrs     x0, mpidr_el1
-    and     x0, x0, #0xFF
+    and     x0, x0, #MPIDR_HWID_MASK_LITE
     cbz     x0, __run
     b       __sleep
 

--- a/chapter2/code0/arch/arm64/main.S
+++ b/chapter2/code0/arch/arm64/main.S
@@ -17,6 +17,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#define MPIDR_HWID_MASK_LITE    0xFFFFFF
+
 .section ".text.boot"
 
 .globl __entry
@@ -29,7 +31,7 @@ __entry:
 
 __el1entry:
     mrs     x0, mpidr_el1
-    and     x0, x0, #0xFF
+    and     x0, x0, #MPIDR_HWID_MASK_LITE
     cbz     x0, __run
     b       __sleep
 

--- a/chapter2/code1/arch/arm64/main.S
+++ b/chapter2/code1/arch/arm64/main.S
@@ -17,6 +17,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#define MPIDR_HWID_MASK_LITE    0xFFFFFF
+
     .macro __ADR_L, dst, sym
         adrp    \dst, \sym
         add     \dst, \dst, :lo12:\sym
@@ -34,7 +36,7 @@ __entry:
 
 __el1entry:
     mrs     x0, mpidr_el1
-    and     x0, x0, #0xFF
+    and     x0, x0, #MPIDR_HWID_MASK_LITE
     cbz     x0, __run
     b       __sleep
 

--- a/chapter2/code2/arch/arm64/main.S
+++ b/chapter2/code2/arch/arm64/main.S
@@ -19,6 +19,8 @@
 
 #include "arch/linux-extension.h"
 
+#define MPIDR_HWID_MASK_LITE    0xFFFFFF
+
 .section ".text.boot"
 
 .globl __entry
@@ -31,7 +33,7 @@ __entry:
 
 __el1entry:
     mrs     x0, mpidr_el1
-    and     x0, x0, #0xFF
+    and     x0, x0, #MPIDR_HWID_MASK_LITE
     cbz     x0, __run
     b       __sleep
 

--- a/chapter2/code3/arch/arm64/main.S
+++ b/chapter2/code3/arch/arm64/main.S
@@ -19,6 +19,8 @@
 
 #include "arch/linux-extension.h"
 
+#define MPIDR_HWID_MASK_LITE    0xFFFFFF
+
 .section ".text.boot"
 
 .globl __entry
@@ -31,7 +33,7 @@ __entry:
 
 __el1entry:
     mrs     x0, mpidr_el1
-    and     x0, x0, #0xFF
+    and     x0, x0, #MPIDR_HWID_MASK_LITE
     cbz     x0, __run
     b       __sleep
 


### PR DESCRIPTION
Problem:
---
- Current masking for SMP ID is sloppy

Solution:
---
- Use MPIDR_HWID_MASK_LITE to support 2^24 - 1 cpus

Issue: #46