### PR TITLE
:bug: Incorrect Configuration for Initial Page Tables

### DIFF
--- a/chapter3/code0/arch/arm64/include/arch/page.h
+++ b/chapter3/code0/arch/arm64/include/arch/page.h
@@ -35,7 +35,7 @@
 #define SECTION_MASK                (~((SECTION_SIZE) - 1))
 
 #define PAGE_TABLE_AF               BIT_SET(10)
-#define PAGE_TABLE_BLOCK            BIT_SET(1)
+#define PAGE_TABLE_BLOCK            BIT_SET(0)
 #define PAGE_TABLE_TABLE            (0b11)
 #define PAGE_TABLE_SH               (0b11 << 8)
 #define PAGE_TABLE_ATTR(n)          (n << 2)

--- a/chapter3/code1/arch/arm64/include/arch/page.h
+++ b/chapter3/code1/arch/arm64/include/arch/page.h
@@ -36,7 +36,7 @@
 #define SECTION_MASK                (~((SECTION_SIZE) - 1))
 
 #define PAGE_TABLE_AF               BIT_SET(10)
-#define PAGE_TABLE_BLOCK            BIT_SET(1)
+#define PAGE_TABLE_BLOCK            BIT_SET(0)
 #define PAGE_TABLE_TABLE            (0b11)
 #define PAGE_TABLE_SH               (0b11 << 8)
 #define PAGE_TABLE_ATTR(n)          (n << 2)


### PR DESCRIPTION
Problem:
---
- In Chapter Three Code One and Code Zero there is an incorrect configuration for the initial page tables
- This results in the valid bit not being set and the first access after the MMU is turned on faults

Solution:
---
- Correct the bug and make the table entries valid

Issue: #61