### PR TITLE
:bug: Incorrect Function Signature for xintos Function

### DIFF
--- a/chapter1/code2/include/cake/string.h
+++ b/chapter1/code2/include/cake/string.h
@@ -15,6 +15,6 @@
 #ifndef _CAKE_STRING_H
 #define _CAKE_STRING_H
 
-void xintos(unsigned x, char *t);
+void xintos(unsigned long x, char *t);
 
 #endif

--- a/chapter2/code0/include/cake/string.h
+++ b/chapter2/code0/include/cake/string.h
@@ -15,6 +15,6 @@
 #ifndef _CAKE_STRING_H
 #define _CAKE_STRING_H
 
-void xintos(unsigned x, char *t);
+void xintos(unsigned long x, char *t);
 
 #endif

--- a/chapter2/code1/include/cake/string.h
+++ b/chapter2/code1/include/cake/string.h
@@ -15,6 +15,6 @@
 #ifndef _CAKE_STRING_H
 #define _CAKE_STRING_H
 
-void xintos(unsigned x, char *t);
+void xintos(unsigned long x, char *t);
 
 #endif

--- a/chapter2/code2/include/cake/string.h
+++ b/chapter2/code2/include/cake/string.h
@@ -15,6 +15,6 @@
 #ifndef _CAKE_STRING_H
 #define _CAKE_STRING_H
 
-void xintos(unsigned x, char *t);
+void xintos(unsigned long x, char *t);
 
 #endif

--- a/chapter2/code3/include/cake/string.h
+++ b/chapter2/code3/include/cake/string.h
@@ -15,6 +15,6 @@
 #ifndef _CAKE_STRING_H
 #define _CAKE_STRING_H
 
-void xintos(unsigned x, char *t);
+void xintos(unsigned long x, char *t);
 
 #endif

--- a/chapter3/code0/include/cake/string.h
+++ b/chapter3/code0/include/cake/string.h
@@ -15,6 +15,6 @@
 #ifndef _CAKE_STRING_H
 #define _CAKE_STRING_H
 
-void xintos(unsigned x, char *t);
+void xintos(unsigned long x, char *t);
 
 #endif


### PR DESCRIPTION
Problem:
---
- In many code folders the xintos function has the wrong function signature in string.h header file
  - It is given as unsigned x
  - Should be unsigned long x

Notes:
---
- Update the signature where it is incorrect
- `find -name string.h -exec sed -i 's/xintos(unsigned x/xintos(unsigned long x/g' {} \;`

Issue: #62