### PR TITLE
:computer: Setup Timer SGI in Chapter Five Code Zero

### DIFF
--- a/chapter5/code0/arch/arm64/board/raspberry-pi-4/irq.S
+++ b/chapter5/code0/arch/arm64/board/raspberry-pi-4/irq.S
@@ -17,10 +17,21 @@
 #include "board/devio.h"
 #include "board/gic.h"
 
+#define SGI_TARGET_LIST_FILTER_SHIFT   (24)
+
 .globl __irq_acknowledge
 __irq_acknowledge:
     __MOV_Q         x0, PHYS_TO_VIRT(GICC_IAR)
     __DEV_READ_32   w0, x0
+    ret
+
+.globl __irq_broadcast_sgi
+__irq_broadcast_sgi:
+    mov             x1, #1
+    lsl             x1, x1, #SGI_TARGET_LIST_FILTER_SHIFT
+    orr             x0, x0, x1
+    __MOV_Q         x1, PHYS_TO_VIRT(GICD_SGIR)
+    __dev_write_32  w0, x1
     ret
 
 .globl __irq_end

--- a/chapter5/code0/arch/arm64/board/raspberry-pi-4/irq.c
+++ b/chapter5/code0/arch/arm64/board/raspberry-pi-4/irq.c
@@ -16,6 +16,7 @@
 #include "board/bare-metal.h"
 #include "board/gic.h"
 
+#define SPID_SGI_TIMER      (0x03)
 #define SPID_TIMER3         (0x63)
 
 #define IRQ_IRQID_SHIFT     (0)
@@ -28,6 +29,7 @@
 #define IRQ_CPUID_VALUE(irq)    ((irq & IRQ_CPUID_MASK) >> IRQ_CPUID_SHIFT)
 
 extern unsigned int __irq_acknowledge();
+extern void __irq_broadcast_sgi(unsigned long sgi);
 extern void __irq_enable_spid(unsigned long spid);
 extern void __irq_end(unsigned int irq);
 extern void __irq_target_cpumask(unsigned long spid, unsigned long mask);
@@ -46,11 +48,15 @@ void handle_irq()
         if(irqid < 1020) {
             __irq_end(irq);
             switch(irqid) {
+                case SPID_SGI_TIMER:
+                    break;
                 case SPID_TIMER3:
+                    __irq_broadcast_sgi(SPID_SGI_TIMER);
                     timer_interrupt();
                     break;
                 default:
                     log("Encountered Undefined Interrupt: %x\r\n");
+                    break;
             }
         }
         else {


### PR DESCRIPTION
Problem:
---
- When secondary CPUs start up they print and wait for interrupt
- They never receive one because timer is set for CPU0

Solution:
---
- Add a Software Generated Interrupt
- It broadcasts the timer interrupt to all CPUs not CPU0

Issue: #74