### PR TITLE
:art: Update UART Code in Ch1/Co0 to Use Transmitter Empty

### DIFF
--- a/chapter1/code0/src/cheesecake.c
+++ b/chapter1/code0/src/cheesecake.c
@@ -17,7 +17,7 @@ extern void uart_puts(char *s);
 
 void cheesecake_main(void)
 {
-    char *version = "Version: 0.1.1\r\n";
+    char *version = "Version: 0.1.0.1\r\n";
     uart_puts("Hello, Cheesecake!\r\n");
     while (1) {
         uart_puts(version);

--- a/chapter1/code0/src/mini-uart.S
+++ b/chapter1/code0/src/mini-uart.S
@@ -16,8 +16,8 @@
 #define UART_BASE_REG           (MAIN_PERIPH_BASE + 0x2215000)
 #define AUX_MU_IO_REG           ((UART_BASE_REG) + 0x40)
 #define AUX_MU_LSR_REG          ((UART_BASE_REG) + 0x54)
-#define AUX_MU_LSR_REG_TISHIFT  (6)
-#define AUX_MU_LSR_REG_TIFLAG   (1 << (AUX_MU_LSR_REG_TISHIFT))
+#define AUX_MU_LSR_REG_TESHIFT  (5)
+#define AUX_MU_LSR_REG_TEFLAG   (1 << (AUX_MU_LSR_REG_TESHIFT))
 
     .macro __MOV_Q, reg, val
 	    .if     (((\val) >> 31) == 0 || ((\val) >> 31) == 0x1ffffffff)
@@ -42,11 +42,11 @@
         strb   \src, [\dst]
     .endm
 
-.globl __uart_can_io
-__uart_can_io:
+.globl __uart_can_tx
+__uart_can_tx:
     __MOV_Q         x0, AUX_MU_LSR_REG
     __DEV_READ_32   w0, x0
-    and             w0, w0, AUX_MU_LSR_REG_TIFLAG
+    and             w0, w0, AUX_MU_LSR_REG_TEFLAG
     ret
 
 .globl __uart_putchar

--- a/chapter1/code0/src/mini-uart.c
+++ b/chapter1/code0/src/mini-uart.c
@@ -12,12 +12,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-extern int  __uart_can_io();
+extern int  __uart_can_tx();
 extern void __uart_putchar(char c);
 
 static inline int check_ready()
 {
-    return __uart_can_io();
+    return __uart_can_tx();
 }
 
 static inline void uart_putchar(char c)


### PR DESCRIPTION
Problem:
---
- The mini-uart putchar is using the transmitter idle flag
- There is a FIFO queue so the transmitter empty flag is possibly better

Solution:
---
- Bit 5 instead of bit 6 of the AUX_MU_LSR_REG register is used to check
- Change __uart_can_io to __uart_can_tx

Issue: #102