### PR TITLE
:office: Update Style Guide to Use Pencil Emoji for Rough Drafts

### DIFF
--- a/style-guide.md
+++ b/style-guide.md
@@ -11,7 +11,7 @@ All opened issues are expected to follow this format:
   - :art: for refactoring or beautification (both code and text)
   - :books: for external documentation
   - :notebook: for notes
-  - :pencil2: for outlines
+  - :pencil2: for rough drafts
   - :black_nib: for production text
   - :microscope: for typos, spelling errors, and broken links
   - :rocket: for something truly spectacular


### PR DESCRIPTION
Problem:
---
- Pencil emoji ( :pencil2: ) currently used for outlines
- Outlines and notes ( :notebook: ) are too close in meaning

solution:
---
- Update style guide to indicate the pencil is for rough drafts

Issue: #89