### PR TITLE
:art: Fixup Ch1/Co1 UART and Main

### DIFF
--- a/chapter1/code1/arch/arm64/board/raspberry-pi-4/mini-uart.S
+++ b/chapter1/code1/arch/arm64/board/raspberry-pi-4/mini-uart.S
@@ -16,8 +16,8 @@
 #define UART_BASE_REG           (MAIN_PERIPH_BASE + 0x2215000)
 #define AUX_MU_IO_REG           ((UART_BASE_REG) + 0x40)
 #define AUX_MU_LSR_REG          ((UART_BASE_REG) + 0x54)
-#define AUX_MU_LSR_REG_TISHIFT  (6)
-#define AUX_MU_LSR_REG_TIFLAG   (1 << (AUX_MU_LSR_REG_TISHIFT))
+#define AUX_MU_LSR_REG_TESHIFT  (5)
+#define AUX_MU_LSR_REG_TEFLAG   (1 << (AUX_MU_LSR_REG_TESHIFT))
 
     .macro __MOV_Q, reg, val
 	    .if     (((\val) >> 31) == 0 || ((\val) >> 31) == 0x1ffffffff)
@@ -42,11 +42,11 @@
         strb   \src, [\dst]
     .endm
 
-.globl __uart_can_io
-__uart_can_io:
+.globl __uart_can_tx
+__uart_can_tx:
     __MOV_Q         x0, AUX_MU_LSR_REG
     __DEV_READ_32   w0, x0
-    and             w0, w0, AUX_MU_LSR_REG_TIFLAG
+    and             w0, w0, AUX_MU_LSR_REG_TEFLAG
     ret
 
 .globl __uart_putchar

--- a/chapter1/code1/arch/arm64/board/raspberry-pi-4/mini-uart.c
+++ b/chapter1/code1/arch/arm64/board/raspberry-pi-4/mini-uart.c
@@ -14,17 +14,19 @@
 
 #include "cake/log.h"
 
-extern int  __uart_can_io();
+extern int  __uart_can_tx();
 extern void __uart_putchar(char c);
 
 static void uart_puts(char *s);
+
 static struct console console = {
     .write = uart_puts
 };
 
+
 static inline int check_ready()
 {
-    return __uart_can_io();
+    return __uart_can_tx();
 }
 
 static inline void uart_putchar(char c)

--- a/chapter1/code1/arch/arm64/main.S
+++ b/chapter1/code1/arch/arm64/main.S
@@ -45,5 +45,5 @@ __zerobss:
     sub     x1, x1, x0
     str     xzr, [x0], #8
     subs    x1, x1, #8
-    b.gt    __zerobss
+    b.hi    __zerobss
     ret

--- a/chapter1/code1/src/cheesecake.c
+++ b/chapter1/code1/src/cheesecake.c
@@ -16,11 +16,12 @@
 #include "arch/timing.h"
 
 extern void log_init();
+
 void init();
 
 void cheesecake_main(void)
 {
-    char *version = "Version: 0.1.2\r\n";
+    char *version = "Version: 0.1.1.2\r\n";
     init();
     log("Hello, Cheesecake!\r\n");
     while (1) {


### PR DESCRIPTION
Problem:
---
- The mini UART code in chapter1/code1 still uses the TI flag instead of TE
- The `__zerobss` routine in `main.S` uses a GT comparison when HI will do (unsigned)

Solution:
---
- Switch to using the TE bit and flag in `mini-uart.S`
- Switch to using HI comparison in `__zerobss` routine

Issue: #107