### PR TITLE
:art: Do Minor Fixes for Ch1/Co1

### DIFF
--- a/chapter1/code1/arch/arm64/board/raspberry-pi-4/mini-uart.c
+++ b/chapter1/code1/arch/arm64/board/raspberry-pi-4/mini-uart.c
@@ -23,7 +23,6 @@ static struct console console = {
     .write = uart_puts
 };
 
-
 static inline int check_ready()
 {
     return __uart_can_tx();

--- a/chapter1/code1/src/cheesecake.c
+++ b/chapter1/code1/src/cheesecake.c
@@ -17,7 +17,7 @@
 
 extern void log_init();
 
-void init();
+static void init();
 
 void cheesecake_main(void)
 {
@@ -31,7 +31,7 @@ void cheesecake_main(void)
     }
 }
 
-void init()
+static void init()
 {
     log_init();
     log("LOG MODULE INITIALIZED\r\n");

--- a/chapter1/conventions-design.md
+++ b/chapter1/conventions-design.md
@@ -63,6 +63,10 @@ The `cheesecake_main` function, still in [src/cheesecake_main.c](code1/src/chees
 #include "cake/log.h"
 #include "arch/timing.h"
 
+extern void log_init();
+
+static void init();
+
 void cheesecake_main(void)
 {
     char *version = "Version: 0.1.1.2\r\n";
@@ -75,7 +79,7 @@ void cheesecake_main(void)
     }
 }
 
-void init()
+static void init()
 {
     log_init();
     log("LOG MODULE INITIALIZED\r\n");


### PR DESCRIPTION
Problem:
---
- The `init` function in `cheesecake.c` is not declared/defined as static
- There is an extra space in the `mini-uart.c` file

Solution:
---
- Declare `cheesecake.c` `init` function as static
- Remove extra space in the `mini-uart.c` file
- Update `convention-design.md` to show the static qualifier for the `init` function

Issue: #111