### PR TITLE
:bug: Add ret Statement to end of __sev routine

### DIFF
--- a/chapter5/code0/arch/arm64/event.S
+++ b/chapter5/code0/arch/arm64/event.S
@@ -17,3 +17,4 @@ __sev:
     sev
     dsb sy
     isb
+    ret

--- a/chapter5/code11/arch/arm64/event.S
+++ b/chapter5/code11/arch/arm64/event.S
@@ -17,3 +17,4 @@ __sev:
     sev
     dsb sy
     isb
+    ret


### PR DESCRIPTION
Problem:
---
- The ret statement is missing from the end of the `__sev` routine

Solution:
---
- Fix in
  - `chapter5/code0/arch/arm64/event.S`
  - `chapter5/code11/arch/arm64/event.S`

Issue: #173