### PR TITLE
:computer: Add Ordering Capabilities to Ch5/Co3

### DIFF
--- a/chapter5/code3/arch/arm64/barrier.S
+++ b/chapter5/code3/arch/arm64/barrier.S
@@ -16,3 +16,13 @@
 __dsb_sy:
     dsb     sy
     ret
+
+.globl __load_acquire
+__load_acquire:
+    ldar    x0, [x0]
+    ret
+
+.globl __store_release
+__store_release:
+    stlr    x1, [x0]
+    ret

--- a/chapter5/code3/arch/arm64/include/arch/barrier.h
+++ b/chapter5/code3/arch/arm64/include/arch/barrier.h
@@ -1,0 +1,41 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _ARCH_BARRIER_H
+#define _ARCH_BARRIER_H
+
+#define sev()                       asm volatile("sev" : : : "memory")
+#define wfe()                       asm volatile("wfe" : : : "memory")
+#define wfi()                       asm volatile("wfi" : : : "memory")
+
+#define isb()                       asm volatile("isb" : : : "memory")
+#define dmb(opt)                    asm volatile("dmb " #opt : : : "memory")
+#define dsb(opt)                    asm volatile("dsb " #opt : : : "memory")
+
+#define sys_mb()                    dsb(sy)
+#define sys_rmb()                   dsb(ld)
+#define sys_wmb()                   dsb(st)
+
+#define smp_mb()                    dmb(ish)
+#define smp_rmb()                   dmb(ishld)
+#define smp_wmb()                   dmb(ishst)
+
+#define LOAD_ACQUIRE(ptr)           __load_acquire(ptr)
+#define STORE_RELEASE(ptr, val)     __store_release(ptr, val)
+
+unsigned long __load_acquire(void *src)
+void __store_release(void *dest, unsigned long val);
+
+#endif
+


### PR DESCRIPTION
Problem:
---
- The SMP chapter has atomics but is missing ordering

Solution:
---
- Add asm volatile barrier macros in arch/barrier.h
- Create `__load_acquire` and `__store_release` assembly functions

Issue: #168 