### PR TITLE
:art: Cleanup ARM64 Architecture Allocate Module

### DIFF
--- a/chapter3/code1/arch/arm64/allocate.c
+++ b/chapter3/code1/arch/arm64/allocate.c
@@ -32,7 +32,7 @@ static unsigned int baby_boot_pointer = 0;
 unsigned long alloc_baby_boot_pages(unsigned int numpages)
 {
     unsigned long addr = 0;
-    if(baby_boot_pointer + (numpages - 1) < NUM_ENTRIES_PER_TABLE) {
+    if(baby_boot_pointer + (numpages - 1) < BABY_BOOT_SIZE) {
         addr = baby_boot_allocator[baby_boot_pointer];
         baby_boot_pointer += numpages;
     }


### PR DESCRIPTION
Problem:
---
- The `arch/arm64/allocate.c` module could use some cleanup in Chapter Three Code One

Solution:
---
- Replace `NUM_TABLE_ENTRIES` with `BABY_BOOT_SIZE` to make use of macro

Issue: #63