### PR TITLE
:bug: Remove TLBI Instruction From memmap_switch

### DIFF
--- a/chapter03/boot-tables.md
+++ b/chapter03/boot-tables.md
@@ -257,7 +257,7 @@ In order to facilitate boot tables, additional useful macros are provied in [arc
 #define TCR_SH0                     BIT_NOT_SET(13) | BIT_NOT_SET(12)
 #define TCR_TG0                     BIT_NOT_SET(15) | BIT_NOT_SET(14)
 #define TCR_T1SZ                    (((UL(64)) - (VA_BITS)) << (TCR_T1SZ_SHIFT))
-#define TCR_A1                      BIT_SET(22)
+#define TCR_A1                      BIT_NOT_SET(22)
 #define TCR_IRGN1                   BIT_NOT_SET(25) | BIT_NOT_SET(24)
 #define TCR_ORGN1                   BIT_NOT_SET(27) | BIT_NOT_SET(26)
 #define TCR_SH1                     BIT_NOT_SET(29) | BIT_NOT_SET(28)

--- a/chapter03/code0/arch/arm64/include/arch/page.h
+++ b/chapter03/code0/arch/arm64/include/arch/page.h
@@ -67,7 +67,7 @@
 #define TCR_SH0                     BIT_NOT_SET(13) | BIT_NOT_SET(12)
 #define TCR_TG0                     BIT_NOT_SET(15) | BIT_NOT_SET(14)
 #define TCR_T1SZ                    (((UL(64)) - (VA_BITS)) << (TCR_T1SZ_SHIFT))
-#define TCR_A1                      BIT_SET(22)
+#define TCR_A1                      BIT_NOT_SET(22)
 #define TCR_IRGN1                   BIT_NOT_SET(25) | BIT_NOT_SET(24)
 #define TCR_ORGN1                   BIT_NOT_SET(27) | BIT_NOT_SET(26)
 #define TCR_SH1                     BIT_NOT_SET(29) | BIT_NOT_SET(28)

--- a/chapter03/code1/arch/arm64/include/arch/page.h
+++ b/chapter03/code1/arch/arm64/include/arch/page.h
@@ -68,7 +68,7 @@
 #define TCR_SH0                     BIT_NOT_SET(13) | BIT_NOT_SET(12)
 #define TCR_TG0                     BIT_NOT_SET(15) | BIT_NOT_SET(14)
 #define TCR_T1SZ                    (((UL(64)) - (VA_BITS)) << (TCR_T1SZ_SHIFT))
-#define TCR_A1                      BIT_SET(22)
+#define TCR_A1                      BIT_NOT_SET(22)
 #define TCR_IRGN1                   BIT_NOT_SET(25) | BIT_NOT_SET(24)
 #define TCR_ORGN1                   BIT_NOT_SET(27) | BIT_NOT_SET(26)
 #define TCR_SH1                     BIT_NOT_SET(29) | BIT_NOT_SET(28)

--- a/chapter03/code2/arch/arm64/include/arch/page.h
+++ b/chapter03/code2/arch/arm64/include/arch/page.h
@@ -72,7 +72,7 @@
 #define TCR_SH0                     BIT_NOT_SET(13) | BIT_NOT_SET(12)
 #define TCR_TG0                     BIT_NOT_SET(15) | BIT_NOT_SET(14)
 #define TCR_T1SZ                    (((UL(64)) - (VA_BITS)) << (TCR_T1SZ_SHIFT))
-#define TCR_A1                      BIT_SET(22)
+#define TCR_A1                      BIT_NOT_SET(22)
 #define TCR_IRGN1                   BIT_NOT_SET(25) | BIT_NOT_SET(24)
 #define TCR_ORGN1                   BIT_NOT_SET(27) | BIT_NOT_SET(26)
 #define TCR_SH1                     BIT_NOT_SET(29) | BIT_NOT_SET(28)

--- a/chapter04/code0/arch/arm64/include/arch/page.h
+++ b/chapter04/code0/arch/arm64/include/arch/page.h
@@ -72,7 +72,7 @@
 #define TCR_SH0                     BIT_SET(13) | BIT_SET(12)
 #define TCR_TG0                     BIT_NOT_SET(15) | BIT_NOT_SET(14)
 #define TCR_T1SZ                    (((UL(64)) - (VA_BITS)) << (TCR_T1SZ_SHIFT))
-#define TCR_A1                      BIT_SET(22)
+#define TCR_A1                      BIT_NOT_SET(22)
 #define TCR_IRGN1                   BIT_NOT_SET(25) | BIT_SET(24)
 #define TCR_ORGN1                   BIT_NOT_SET(27) | BIT_SET(26)
 #define TCR_SH1                     BIT_SET(29) | BIT_SET(28)

--- a/chapter05/code0/arch/arm64/include/arch/page.h
+++ b/chapter05/code0/arch/arm64/include/arch/page.h
@@ -72,7 +72,7 @@
 #define TCR_SH0                     BIT_SET(13) | BIT_SET(12)
 #define TCR_TG0                     BIT_NOT_SET(15) | BIT_NOT_SET(14)
 #define TCR_T1SZ                    (((UL(64)) - (VA_BITS)) << (TCR_T1SZ_SHIFT))
-#define TCR_A1                      BIT_SET(22)
+#define TCR_A1                      BIT_NOT_SET(22)
 #define TCR_IRGN1                   BIT_NOT_SET(25) | BIT_SET(24)
 #define TCR_ORGN1                   BIT_NOT_SET(27) | BIT_SET(26)
 #define TCR_SH1                     BIT_SET(29) | BIT_SET(28)

--- a/chapter05/code1/arch/arm64/include/arch/page.h
+++ b/chapter05/code1/arch/arm64/include/arch/page.h
@@ -72,7 +72,7 @@
 #define TCR_SH0                     BIT_SET(13) | BIT_SET(12)
 #define TCR_TG0                     BIT_NOT_SET(15) | BIT_NOT_SET(14)
 #define TCR_T1SZ                    (((UL(64)) - (VA_BITS)) << (TCR_T1SZ_SHIFT))
-#define TCR_A1                      BIT_SET(22)
+#define TCR_A1                      BIT_NOT_SET(22)
 #define TCR_IRGN1                   BIT_NOT_SET(25) | BIT_SET(24)
 #define TCR_ORGN1                   BIT_NOT_SET(27) | BIT_SET(26)
 #define TCR_SH1                     BIT_SET(29) | BIT_SET(28)

--- a/chapter05/code11/arch/arm64/include/arch/page.h
+++ b/chapter05/code11/arch/arm64/include/arch/page.h
@@ -72,7 +72,7 @@
 #define TCR_SH0                     BIT_SET(13) | BIT_SET(12)
 #define TCR_TG0                     BIT_NOT_SET(15) | BIT_NOT_SET(14)
 #define TCR_T1SZ                    (((UL(64)) - (VA_BITS)) << (TCR_T1SZ_SHIFT))
-#define TCR_A1                      BIT_SET(22)
+#define TCR_A1                      BIT_NOT_SET(22)
 #define TCR_IRGN1                   BIT_NOT_SET(25) | BIT_SET(24)
 #define TCR_ORGN1                   BIT_NOT_SET(27) | BIT_SET(26)
 #define TCR_SH1                     BIT_SET(29) | BIT_SET(28)

--- a/chapter05/code3/arch/arm64/include/arch/page.h
+++ b/chapter05/code3/arch/arm64/include/arch/page.h
@@ -72,7 +72,7 @@
 #define TCR_SH0                     BIT_SET(13) | BIT_SET(12)
 #define TCR_TG0                     BIT_NOT_SET(15) | BIT_NOT_SET(14)
 #define TCR_T1SZ                    (((UL(64)) - (VA_BITS)) << (TCR_T1SZ_SHIFT))
-#define TCR_A1                      BIT_SET(22)
+#define TCR_A1                      BIT_NOT_SET(22)
 #define TCR_IRGN1                   BIT_NOT_SET(25) | BIT_SET(24)
 #define TCR_ORGN1                   BIT_NOT_SET(27) | BIT_SET(26)
 #define TCR_SH1                     BIT_SET(29) | BIT_SET(28)

--- a/chapter06/code0/arch/arm64/include/arch/page.h
+++ b/chapter06/code0/arch/arm64/include/arch/page.h
@@ -72,7 +72,7 @@
 #define TCR_SH0                     BIT_SET(13) | BIT_SET(12)
 #define TCR_TG0                     BIT_NOT_SET(15) | BIT_NOT_SET(14)
 #define TCR_T1SZ                    (((UL(64)) - (VA_BITS)) << (TCR_T1SZ_SHIFT))
-#define TCR_A1                      BIT_SET(22)
+#define TCR_A1                      BIT_NOT_SET(22)
 #define TCR_IRGN1                   BIT_NOT_SET(25) | BIT_SET(24)
 #define TCR_ORGN1                   BIT_NOT_SET(27) | BIT_SET(26)
 #define TCR_SH1                     BIT_SET(29) | BIT_SET(28)

--- a/chapter06/code1/arch/arm64/include/arch/page.h
+++ b/chapter06/code1/arch/arm64/include/arch/page.h
@@ -72,7 +72,7 @@
 #define TCR_SH0                     BIT_SET(13) | BIT_SET(12)
 #define TCR_TG0                     BIT_NOT_SET(15) | BIT_NOT_SET(14)
 #define TCR_T1SZ                    (((UL(64)) - (VA_BITS)) << (TCR_T1SZ_SHIFT))
-#define TCR_A1                      BIT_SET(22)
+#define TCR_A1                      BIT_NOT_SET(22)
 #define TCR_IRGN1                   BIT_NOT_SET(25) | BIT_SET(24)
 #define TCR_ORGN1                   BIT_NOT_SET(27) | BIT_SET(26)
 #define TCR_SH1                     BIT_SET(29) | BIT_SET(28)

--- a/chapter06/code2/arch/arm64/include/arch/page.h
+++ b/chapter06/code2/arch/arm64/include/arch/page.h
@@ -72,7 +72,7 @@
 #define TCR_SH0                     BIT_SET(13) | BIT_SET(12)
 #define TCR_TG0                     BIT_NOT_SET(15) | BIT_NOT_SET(14)
 #define TCR_T1SZ                    (((UL(64)) - (VA_BITS)) << (TCR_T1SZ_SHIFT))
-#define TCR_A1                      BIT_SET(22)
+#define TCR_A1                      BIT_NOT_SET(22)
 #define TCR_IRGN1                   BIT_NOT_SET(25) | BIT_SET(24)
 #define TCR_ORGN1                   BIT_NOT_SET(27) | BIT_SET(26)
 #define TCR_SH1                     BIT_SET(29) | BIT_SET(28)

--- a/chapter07/code0/arch/arm64/include/arch/page.h
+++ b/chapter07/code0/arch/arm64/include/arch/page.h
@@ -72,7 +72,7 @@
 #define TCR_SH0                     BIT_SET(13) | BIT_SET(12)
 #define TCR_TG0                     BIT_NOT_SET(15) | BIT_NOT_SET(14)
 #define TCR_T1SZ                    (((UL(64)) - (VA_BITS)) << (TCR_T1SZ_SHIFT))
-#define TCR_A1                      BIT_SET(22)
+#define TCR_A1                      BIT_NOT_SET(22)
 #define TCR_IRGN1                   BIT_NOT_SET(25) | BIT_SET(24)
 #define TCR_ORGN1                   BIT_NOT_SET(27) | BIT_SET(26)
 #define TCR_SH1                     BIT_SET(29) | BIT_SET(28)

--- a/chapter07/code1/arch/arm64/include/arch/page.h
+++ b/chapter07/code1/arch/arm64/include/arch/page.h
@@ -72,7 +72,7 @@
 #define TCR_SH0                     BIT_SET(13) | BIT_SET(12)
 #define TCR_TG0                     BIT_NOT_SET(15) | BIT_NOT_SET(14)
 #define TCR_T1SZ                    (((UL(64)) - (VA_BITS)) << (TCR_T1SZ_SHIFT))
-#define TCR_A1                      BIT_SET(22)
+#define TCR_A1                      BIT_NOT_SET(22)
 #define TCR_IRGN1                   BIT_NOT_SET(25) | BIT_SET(24)
 #define TCR_ORGN1                   BIT_NOT_SET(27) | BIT_SET(26)
 #define TCR_SH1                     BIT_SET(29) | BIT_SET(28)

--- a/chapter07/code2/arch/arm64/include/arch/page.h
+++ b/chapter07/code2/arch/arm64/include/arch/page.h
@@ -72,7 +72,7 @@
 #define TCR_SH0                     BIT_SET(13) | BIT_SET(12)
 #define TCR_TG0                     BIT_NOT_SET(15) | BIT_NOT_SET(14)
 #define TCR_T1SZ                    (((UL(64)) - (VA_BITS)) << (TCR_T1SZ_SHIFT))
-#define TCR_A1                      BIT_SET(22)
+#define TCR_A1                      BIT_NOT_SET(22)
 #define TCR_IRGN1                   BIT_NOT_SET(25) | BIT_SET(24)
 #define TCR_ORGN1                   BIT_NOT_SET(27) | BIT_SET(26)
 #define TCR_SH1                     BIT_SET(29) | BIT_SET(28)

--- a/chapter08/code0/arch/arm64/include/arch/page.h
+++ b/chapter08/code0/arch/arm64/include/arch/page.h
@@ -72,7 +72,7 @@
 #define TCR_SH0                     BIT_SET(13) | BIT_SET(12)
 #define TCR_TG0                     BIT_NOT_SET(15) | BIT_NOT_SET(14)
 #define TCR_T1SZ                    (((UL(64)) - (VA_BITS)) << (TCR_T1SZ_SHIFT))
-#define TCR_A1                      BIT_SET(22)
+#define TCR_A1                      BIT_NOT_SET(22)
 #define TCR_IRGN1                   BIT_NOT_SET(25) | BIT_SET(24)
 #define TCR_ORGN1                   BIT_NOT_SET(27) | BIT_SET(26)
 #define TCR_SH1                     BIT_SET(29) | BIT_SET(28)

--- a/chapter08/code1/arch/arm64/include/arch/page.h
+++ b/chapter08/code1/arch/arm64/include/arch/page.h
@@ -72,7 +72,7 @@
 #define TCR_SH0                     BIT_SET(13) | BIT_SET(12)
 #define TCR_TG0                     BIT_NOT_SET(15) | BIT_NOT_SET(14)
 #define TCR_T1SZ                    (((UL(64)) - (VA_BITS)) << (TCR_T1SZ_SHIFT))
-#define TCR_A1                      BIT_SET(22)
+#define TCR_A1                      BIT_NOT_SET(22)
 #define TCR_IRGN1                   BIT_NOT_SET(25) | BIT_SET(24)
 #define TCR_ORGN1                   BIT_NOT_SET(27) | BIT_SET(26)
 #define TCR_SH1                     BIT_SET(29) | BIT_SET(28)

--- a/chapter09/code0/arch/arm64/include/arch/page.h
+++ b/chapter09/code0/arch/arm64/include/arch/page.h
@@ -72,7 +72,7 @@
 #define TCR_SH0                     BIT_SET(13) | BIT_SET(12)
 #define TCR_TG0                     BIT_NOT_SET(15) | BIT_NOT_SET(14)
 #define TCR_T1SZ                    (((UL(64)) - (VA_BITS)) << (TCR_T1SZ_SHIFT))
-#define TCR_A1                      BIT_SET(22)
+#define TCR_A1                      BIT_NOT_SET(22)
 #define TCR_IRGN1                   BIT_NOT_SET(25) | BIT_SET(24)
 #define TCR_ORGN1                   BIT_NOT_SET(27) | BIT_SET(26)
 #define TCR_SH1                     BIT_SET(29) | BIT_SET(28)

--- a/chapter09/code0/arch/arm64/schedule.S
+++ b/chapter09/code0/arch/arm64/schedule.S
@@ -52,7 +52,6 @@ __memmap_switch:
     and         x2, x3, x2
     msr         ttbr0_el1, x2
     isb
-    tlbi        vmalle1
     bfi         x0, x1, #48, #16
     msr         ttbr0_el1, x0
     isb

--- a/chapter09/code1/arch/arm64/include/arch/page.h
+++ b/chapter09/code1/arch/arm64/include/arch/page.h
@@ -72,7 +72,7 @@
 #define TCR_SH0                     BIT_SET(13) | BIT_SET(12)
 #define TCR_TG0                     BIT_NOT_SET(15) | BIT_NOT_SET(14)
 #define TCR_T1SZ                    (((UL(64)) - (VA_BITS)) << (TCR_T1SZ_SHIFT))
-#define TCR_A1                      BIT_SET(22)
+#define TCR_A1                      BIT_NOT_SET(22)
 #define TCR_IRGN1                   BIT_NOT_SET(25) | BIT_SET(24)
 #define TCR_ORGN1                   BIT_NOT_SET(27) | BIT_SET(26)
 #define TCR_SH1                     BIT_SET(29) | BIT_SET(28)

--- a/chapter09/code1/arch/arm64/schedule.S
+++ b/chapter09/code1/arch/arm64/schedule.S
@@ -52,7 +52,6 @@ __memmap_switch:
     and         x2, x3, x2
     msr         ttbr0_el1, x2
     isb
-    tlbi        vmalle1
     bfi         x0, x1, #48, #16
     msr         ttbr0_el1, x0
     isb

--- a/chapter09/code2/arch/arm64/include/arch/page.h
+++ b/chapter09/code2/arch/arm64/include/arch/page.h
@@ -72,7 +72,7 @@
 #define TCR_SH0                     BIT_SET(13) | BIT_SET(12)
 #define TCR_TG0                     BIT_NOT_SET(15) | BIT_NOT_SET(14)
 #define TCR_T1SZ                    (((UL(64)) - (VA_BITS)) << (TCR_T1SZ_SHIFT))
-#define TCR_A1                      BIT_SET(22)
+#define TCR_A1                      BIT_NOT_SET(22)
 #define TCR_IRGN1                   BIT_NOT_SET(25) | BIT_SET(24)
 #define TCR_ORGN1                   BIT_NOT_SET(27) | BIT_SET(26)
 #define TCR_SH1                     BIT_SET(29) | BIT_SET(28)

--- a/chapter09/code2/arch/arm64/schedule.S
+++ b/chapter09/code2/arch/arm64/schedule.S
@@ -52,7 +52,6 @@ __memmap_switch:
     and         x2, x3, x2
     msr         ttbr0_el1, x2
     isb
-    tlbi        vmalle1
     bfi         x0, x1, #48, #16
     msr         ttbr0_el1, x0
     isb

--- a/chapter09/code3/arch/arm64/include/arch/page.h
+++ b/chapter09/code3/arch/arm64/include/arch/page.h
@@ -72,7 +72,7 @@
 #define TCR_SH0                     BIT_SET(13) | BIT_SET(12)
 #define TCR_TG0                     BIT_NOT_SET(15) | BIT_NOT_SET(14)
 #define TCR_T1SZ                    (((UL(64)) - (VA_BITS)) << (TCR_T1SZ_SHIFT))
-#define TCR_A1                      BIT_SET(22)
+#define TCR_A1                      BIT_NOT_SET(22)
 #define TCR_IRGN1                   BIT_NOT_SET(25) | BIT_SET(24)
 #define TCR_ORGN1                   BIT_NOT_SET(27) | BIT_SET(26)
 #define TCR_SH1                     BIT_SET(29) | BIT_SET(28)

--- a/chapter09/code3/arch/arm64/schedule.S
+++ b/chapter09/code3/arch/arm64/schedule.S
@@ -52,7 +52,6 @@ __memmap_switch:
     and         x2, x3, x2
     msr         ttbr0_el1, x2
     isb
-    tlbi        vmalle1
     bfi         x0, x1, #48, #16
     msr         ttbr0_el1, x0
     isb


### PR DESCRIPTION
Problem:
---
- In earliest examples `memmap_switch` has a TLBI instruction
- Also, `TCR_EL1.A1` is incorrectly set to 1

Solution:
---
- Remove the TLBI from `__memmap_switch` in `arch/arm64/schedule.S`
- Set `TCR_EL1.A1` to zero, making `TTBR0_EL1` the ASID definer

Issue: #287