### PR TITLE
:microscope: Update Version Strings Where Relevant

### DIFF
--- a/chapter06/code1/src/cheesecake.c
+++ b/chapter06/code1/src/cheesecake.c
@@ -47,7 +47,7 @@ void cheesecake_main(void)
 static void do_idle()
 {
     unsigned long cpuid = SMP_ID();
-    char *version = "0.6.0.17";
+    char *version = "0.6.1.17";
     while (1) {
         unsigned long flags = SPIN_LOCK_IRQSAVE(&big_cake_lock);
         log("Version: %s\r\n", version);

--- a/chapter06/code2/src/cheesecake.c
+++ b/chapter06/code2/src/cheesecake.c
@@ -47,7 +47,7 @@ void cheesecake_main(void)
 static void do_idle()
 {
     unsigned long cpuid = SMP_ID();
-    char *version = "0.6.0.17";
+    char *version = "0.6.2.18";
     while (1) {
         unsigned long flags = SPIN_LOCK_IRQSAVE(&big_cake_lock);
         log("Version: %s\r\n", version);


### PR DESCRIPTION
Problem:
---
- CheesecakeOS prints an incorrect version string on a few builds
  - Version 0.6.1.17 prints 0.6.0.17
  - Version 0.6.2.18 prints 0.6.0.17

Solution:
---
- Correct the version string

Issue: #200