### PR TITLE
:bug: Return Null Value If Size Cache Does Not Exist

### DIFF
--- a/chapter08/code0/src/allocate.c
+++ b/chapter08/code0/src/allocate.c
@@ -297,6 +297,9 @@ void *cake_alloc(unsigned long size)
     struct cache *sizecache;
     unsigned int index;
     index = cake_alloc_index(size);
+    if(index < 0) {
+        return 0;
+    }
     sizecache = &(sizecaches[index]);
     return alloc_obj(sizecache);
 }

--- a/chapter08/code1/src/allocate.c
+++ b/chapter08/code1/src/allocate.c
@@ -297,6 +297,9 @@ void *cake_alloc(unsigned long size)
     struct cache *sizecache;
     unsigned int index;
     index = cake_alloc_index(size);
+    if(index < 0) {
+        return 0;
+    }
     sizecache = &(sizecaches[index]);
     return alloc_obj(sizecache);
 }

--- a/chapter09/code0/src/allocate.c
+++ b/chapter09/code0/src/allocate.c
@@ -299,6 +299,9 @@ void *cake_alloc(unsigned long size)
     struct cache *sizecache;
     unsigned int index;
     index = cake_alloc_index(size);
+    if(index < 0) {
+        return 0;
+    }
     sizecache = &(sizecaches[index]);
     return alloc_obj(sizecache);
 }

--- a/chapter09/code1/src/allocate.c
+++ b/chapter09/code1/src/allocate.c
@@ -299,6 +299,9 @@ void *cake_alloc(unsigned long size)
     struct cache *sizecache;
     unsigned int index;
     index = cake_alloc_index(size);
+    if(index < 0) {
+        return 0;
+    }
     sizecache = &(sizecaches[index]);
     return alloc_obj(sizecache);
 }

--- a/chapter09/code2/src/allocate.c
+++ b/chapter09/code2/src/allocate.c
@@ -299,6 +299,9 @@ void *cake_alloc(unsigned long size)
     struct cache *sizecache;
     unsigned int index;
     index = cake_alloc_index(size);
+    if(index < 0) {
+        return 0;
+    }
     sizecache = &(sizecaches[index]);
     return alloc_obj(sizecache);
 }

--- a/chapter09/code3/src/allocate.c
+++ b/chapter09/code3/src/allocate.c
@@ -299,6 +299,9 @@ void *cake_alloc(unsigned long size)
     struct cache *sizecache;
     unsigned int index;
     index = cake_alloc_index(size);
+    if(index < 0) {
+        return 0;
+    }
     sizecache = &(sizecaches[index]);
     return alloc_obj(sizecache);
 }

--- a/chapter10/code0/src/allocate.c
+++ b/chapter10/code0/src/allocate.c
@@ -299,6 +299,9 @@ void *cake_alloc(unsigned long size)
     struct cache *sizecache;
     unsigned int index;
     index = cake_alloc_index(size);
+    if(index < 0) {
+        return 0;
+    }
     sizecache = &(sizecaches[index]);
     return alloc_obj(sizecache);
 }

--- a/chapter10/code1/src/allocate.c
+++ b/chapter10/code1/src/allocate.c
@@ -299,6 +299,9 @@ void *cake_alloc(unsigned long size)
     struct cache *sizecache;
     unsigned int index;
     index = cake_alloc_index(size);
+    if(index < 0) {
+        return 0;
+    }
     sizecache = &(sizecaches[index]);
     return alloc_obj(sizecache);
 }

--- a/chapter10/code2/src/allocate.c
+++ b/chapter10/code2/src/allocate.c
@@ -299,6 +299,9 @@ void *cake_alloc(unsigned long size)
     struct cache *sizecache;
     unsigned int index;
     index = cake_alloc_index(size);
+    if(index < 0) {
+        return 0;
+    }
     sizecache = &(sizecaches[index]);
     return alloc_obj(sizecache);
 }

--- a/chapter11/code0/src/allocate.c
+++ b/chapter11/code0/src/allocate.c
@@ -299,6 +299,9 @@ void *cake_alloc(unsigned long size)
     struct cache *sizecache;
     unsigned int index;
     index = cake_alloc_index(size);
+    if(index < 0) {
+        return 0;
+    }
     sizecache = &(sizecaches[index]);
     return alloc_obj(sizecache);
 }

--- a/chapter11/code1/src/allocate.c
+++ b/chapter11/code1/src/allocate.c
@@ -299,6 +299,9 @@ void *cake_alloc(unsigned long size)
     struct cache *sizecache;
     unsigned int index;
     index = cake_alloc_index(size);
+    if(index < 0) {
+        return 0;
+    }
     sizecache = &(sizecaches[index]);
     return alloc_obj(sizecache);
 }

--- a/chapter12/code0/src/allocate.c
+++ b/chapter12/code0/src/allocate.c
@@ -299,6 +299,9 @@ void *cake_alloc(unsigned long size)
     struct cache *sizecache;
     unsigned int index;
     index = cake_alloc_index(size);
+    if(index < 0) {
+        return 0;
+    }
     sizecache = &(sizecaches[index]);
     return alloc_obj(sizecache);
 }

--- a/chapter13/code0/src/allocate.c
+++ b/chapter13/code0/src/allocate.c
@@ -299,6 +299,9 @@ void *cake_alloc(unsigned long size)
     struct cache *sizecache;
     unsigned int index;
     index = cake_alloc_index(size);
+    if(index < 0) {
+        return 0;
+    }
     sizecache = &(sizecaches[index]);
     return alloc_obj(sizecache);
 }


### PR DESCRIPTION
Problem:
---
- The `cake_alloc` function may receive an allocation size request that is too large
- In this case the index lookup will return -1
- This will lead to an invalid lookup

Solution:
---
- Return 0 if this happens

Issue: #224