### PR TITLE
:bug: Failed to Clear Reference Map in PID Module

### DIFF
--- a/chapter12/code0/src/pid.c
+++ b/chapter12/code0/src/pid.c
@@ -112,6 +112,7 @@ void pid_put(unsigned int pid)
         reference->refcount--;
         if(!(reference->refcount)) {
             p = reference->process;
+            refmap[pid] = 0;
             cake_free(reference);
             deallocate = 1;
         }

--- a/chapter12/shell.md
+++ b/chapter12/shell.md
@@ -406,6 +406,7 @@ void pid_put(unsigned int pid)
         reference->refcount--;
         if(!(reference->refcount)) {
             p = reference->process;
+            refmap[pid] = 0;
             cake_free(reference);
             deallocate = 1;
         }

--- a/chapter13/code0/src/pid.c
+++ b/chapter13/code0/src/pid.c
@@ -112,6 +112,7 @@ void pid_put(unsigned int pid)
         reference->refcount--;
         if(!(reference->refcount)) {
             p = reference->process;
+            refmap[pid] = 0;
             cake_free(reference);
             deallocate = 1;
         }


### PR DESCRIPTION
Problem:
---
- In `pid_put` the reference map is not cleared when the reference is freed
- This can lead to a race condition where a PID returns an invalid process reference

Solution:
---
- Clear the reference map when the reference count reaches zero

Issue: #468